### PR TITLE
Fix hound lint complaints

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
   "env": {
     "es6": true,
     "browser": true,
-    "node": true
+    "node": true,
+    "jasmine": true,
   },
   "extends": "eslint:recommended",
   "ecmaFeatures": {


### PR DESCRIPTION
Sadly, hound doesn't understand that each directory can have its own
eslint config. So we have to combine the eslint configs with the spec
eslint config :(