### PR TITLE
Make collapsing nodes sticky

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -48,7 +48,7 @@ export class AST {
   patch(newAST) {
     var patches = jsonpatch.compare(this.rootNodes, newAST.rootNodes);
     // don't remove references to DOM elements
-    patches = patches.filter(p => p.path.split('/').pop() !== "el");
+    patches = patches.filter(p => !['el', 'collapsed'].includes(p.path.split('/').pop()));
     jsonpatch.apply(this.rootNodes, patches);
     // refresh nodeMaps and re-annotate
     this.nodeMap = new Map();

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -324,9 +324,9 @@ export default class CodeMirrorBlocks {
   // render : Void -> Void
   // re-parse the document, then (ideally) patch and re-render the resulting AST
   render() {
-    this.ast = this.parser.parse(this.cm.getValue());
+    //this.ast = this.parser.parse(this.cm.getValue());
     this._clearMarks();
-    //this.ast.patch(this.parser.parse(this.cm.getValue()));
+    this.ast.patch(this.parser.parse(this.cm.getValue()));
     //console.log('patched AST is ', this.ast.rootNodes);
     this.renderer.renderAST(this.ast, this.focusPath);
     ui.renderToolbarInto(this);
@@ -778,6 +778,7 @@ export default class CodeMirrorBlocks {
       let isExpanded = !(node.el.getAttribute("aria-expanded")=="false");
       if(makeExpanded !== isExpanded) {
         node.el.setAttribute("aria-expanded", !isExpanded);
+        node.collapsed = isExpanded;
       }
       that.cm.refresh();
       return makeExpanded !== isExpanded;

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -13,13 +13,6 @@ export default class Node extends PureComponent {
     lockedTypes: PropTypes.instanceOf(Array).isRequired,
   }
 
-  constructor() {
-    super();
-    this.state = {
-      expanded: true
-    };
-  }
-
   render() {
     const {type, node, lockedTypes, helpers, children} = this.props;
     let locked = lockedTypes.includes(type);
@@ -40,7 +33,7 @@ export default class Node extends PureComponent {
         aria-label      = { node.options['aria-label'] }
         aria-describedby= { node.options.comment? `block-node-${node.options.comment.id}`: undefined}
         aria-disabled   = { locked? "true": undefined }
-        aria-expanded   = { locked? "false": expandable? "true" : undefined}
+        aria-expanded   = { locked? "false": expandable? (node.collapsed ? "false" : "true") : undefined}
         aria-setsize    = { node["aria-setsize"]  }
         aria-posinset   = { node["aria-posinset"] }
         aria-level      = { node["aria-level"]    }


### PR DESCRIPTION
So this is a working proof of concept that shows how to get nodes to remain collapsed after editing other nodes. For any UI state that needs to be sticky across edits, the following must occur:

1. The state for that UI must be stored directly on the AST node
2. The AST node that has that state must get _patched_ rather than blown away by the parser
3. The react component that renders that node must look at the state stored on the node when deciding how to render the node.

The render loop looks like this:

0. parse codemirror text into AST
1. render AST using react components
2. attach various events to rendered dom nodes
3. user collapses a node in the tree
3a. dom is updated to reflect user's action
3b. AST node is updated to reflect user's action
4. user goes through edit flow for a different node
5. user "saves" the edit by hitting enter
5a. underlying codemirror text is updated
6. parse new codemirror text into new AST (does not containt collapse state)
7. patch existing AST (containing collapse state) using the new AST (collapse state should survive the patching process)
8. go to step 1.

The parts you were missing were storing the state on the ast node and rendering the UI based on that state. You can't just try to keep around the underlying dom elements because they will get re-rendered by react every render cycle.