### PR TITLE
Add Sequences to block language

### DIFF
--- a/spec/ast-test.js
+++ b/spec/ast-test.js
@@ -84,7 +84,7 @@ describe("The Sequence Class", function() {
 
   it("should take an optional options parameter in it's constructor", function() {
     var options = {'aria-label': 'sequence'};
-    var newSequence = new Sequence(from, to, exprs, name, options)
+    var newSequence = new Sequence(from, to, exprs, name, options);
     expect(newSequence.options).toEqual(options);
   });
 });

--- a/spec/ast-test.js
+++ b/spec/ast-test.js
@@ -1,4 +1,4 @@
-import {AST, Literal, Expression} from 'codemirror-blocks/ast';
+import {AST, Literal, Expression, Sequence} from 'codemirror-blocks/ast';
 
 describe("The Literal Class", function() {
   it("should be constructed with a value and data type", function() {
@@ -33,6 +33,60 @@ describe("The Literal Class", function() {
     expect(literal.options).toEqual({'aria-label':'11'});
   });
 
+});
+
+describe("The Sequence Class", function() {
+  var sequence, expression1, expression2, from, to, name, exprs;
+
+  beforeEach(function() {
+    // (+ 1 2)
+    var func1 = new Literal({line: 0, ch: 8}, {line: 0, ch: 9}, '+', 'symbol');
+    var args1 = [
+      new Literal({line: 0, ch: 10}, {line: 0, ch: 11}, 1),
+      new Literal({line: 0, ch: 12}, {line: 0, ch: 13}, 2)
+    ];
+    expression1 = new Expression(
+      {line: 0, ch: 7},
+      {line: 0, ch: 14},
+      func1,
+      args1,
+      {'aria-label':'+ expression'}
+    );
+
+    // (- 2 3)
+    var func2 = new Literal({line: 0, ch: 16}, {line: 0, ch: 17}, '-', 'symbol');
+    var args2 = [
+      new Literal({line: 0, ch: 18}, {line: 0, ch: 19}, 2),
+      new Literal({line: 0, ch: 20}, {line: 0, ch: 21}, 3)
+    ];
+    expression2 = new Expression(
+      {line: 0, ch: 15},
+      {line: 0, ch: 22},
+      func2,
+      args2,
+      {'aria-label':'+ expression'}
+    );
+
+    // (begin (+ 1 2) (- 2 3))
+    from = {line: 0, ch: 0};
+    to = {line: 0, ch: 23};
+    name = 'begin';
+    exprs = [expression1, expression2];
+    sequence = new Sequence(from, to, exprs, name);
+  });
+
+  it("should be constructed with a list of expressions", function() {
+    expect(sequence.from).toBe(from);
+    expect(sequence.to).toBe(to);
+    expect(sequence.exprs).toBe(exprs);
+    expect(sequence.name).toEqual(name);
+  });
+
+  it("should take an optional options parameter in it's constructor", function() {
+    var options = {'aria-label': 'sequence'};
+    var newSequence = new Sequence(from, to, exprs, name, options)
+    expect(newSequence.options).toEqual(options);
+  });
 });
 
 describe("The Expression Class", function() {

--- a/spec/languages/wescheme/WeschemeParser-test.js
+++ b/spec/languages/wescheme/WeschemeParser-test.js
@@ -274,10 +274,6 @@ describe("The WeScheme Parser,", function() {
       this.ast = this.parser.parse('(letrec ((x 42)) x)');
       expect(this.ast.rootNodes.length).toBe(0);
     });
-    it("should ignore letStar", function() {
-      this.ast = this.parser.parse('(begin (+ 1 2) (+ 3 4) 5)');
-      expect(this.ast.rootNodes.length).toBe(0);
-    });
     it("should ignore whenExpr", function() {
       this.ast = this.parser.parse('(when (> 3 2) x)');
       expect(this.ast.rootNodes.length).toBe(0);

--- a/spec/languages/wescheme/WeschemeParser-test.js
+++ b/spec/languages/wescheme/WeschemeParser-test.js
@@ -221,6 +221,37 @@ describe("The WeScheme Parser,", function() {
     });
   });
 
+  describe("when parsing sequences,", function() {
+    beforeEach(function() {
+      this.ast = this.parser.parse('(begin (- (+ 1 2) 5) (print "hello"))');
+    });
+
+    it("should convert beginExpr to a sequence", function() {
+      expect(this.ast.rootNodes[0].type).toBe('sequence');
+    });
+
+    it("should get the correct name of the sequence", function() {
+      expect(this.ast.rootNodes[0].name).toBe('begin');
+    });
+
+    it("should convert the sequence's expressions correctly", function() {
+      expect(this.ast.rootNodes[0].exprs[0].type).toBe('expression');
+      expect(this.ast.rootNodes[0].exprs[1].type).toBe('expression');
+    });
+
+    it("should leave the expressions in the order that they appeared in the sequence", function() {
+      expect(this.ast.rootNodes[0].exprs[0].func.value).toBe('-');
+      expect(this.ast.rootNodes[0].exprs[1].func.value).toBe('print');
+    });
+
+    it("should preserve nested expressions in the sequence", function() {
+      var firstExpression = this.ast.rootNodes[0].exprs[0];
+      expect(firstExpression.func.value).toBe('-');
+      expect(firstExpression.args[0].type).toBe('expression');
+      expect(firstExpression.args[1].type).toBe('literal');
+    });
+  });
+
   describe("when parsing expressions that are unsupported in the block language,", function() {
 
     it("should ignore defVars", function() {

--- a/spec/wescheme-parser-test.js
+++ b/spec/wescheme-parser-test.js
@@ -3,9 +3,13 @@ import CodeMirror from 'codemirror';
 import WeschemeParser from 'codemirror-blocks/languages/wescheme/WeschemeParser';
 
 import { 
+  click,
   dragstart,
   drop
 } from './events';
+
+const LEFT_KEY  = 37;
+const RIGHT_KEY = 39;
 const DOWN_KEY  = 40;
 
 function keydown(keyCode, other={}) {
@@ -90,6 +94,28 @@ describe('The CodeMirrorBlocks Class', function() {
         this.fourthArg.el.dispatchEvent(drop(dragEvent.dataTransfer));
         expect(this.cm.getValue().replace(/\s+/, ' ')).toBe('( 1 2 3 +)');
       });
+    });
+  });
+  
+  describe('when parsing code with sequences,', function() {
+    beforeEach(function() {
+      this.cm.setValue(`(begin (+ 1 2) (- 3 4))`);
+      this.blocks.setBlockMode(true);
+      this.sequence = this.blocks.ast.rootNodes[0];
+    });
+
+    it('sequence blocks should be collapsible', function() {
+      this.sequence.el.dispatchEvent(click());
+      this.sequence.el.dispatchEvent(keydown(LEFT_KEY));
+      expect(this.sequence.el.getAttribute("aria-expanded")).toBe("false");
+      this.sequence.el.dispatchEvent(keydown(RIGHT_KEY));
+      expect(document.activeElement).toBe(this.sequence.el);
+    });
+
+    it('should allow moving through expressions in sequences', function() {
+      this.sequence.el.dispatchEvent(click());
+      this.sequence.el.dispatchEvent(keydown(DOWN_KEY));
+      expect(document.activeElement).toBe(this.sequence.exprs[0].el);
     });
   });
 /*

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -35,6 +35,7 @@ export default class Renderer {
       structDefinition: StructDefinition,
       literal: Literal,
       comment: Comment,
+      sequence: Sequence,
       blank: Blank
     };
   }

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -10,10 +10,11 @@ import Unknown          from './components/Unknown';
 import Literal          from './components/Literal';
 import Blank            from './components/Blank';
 import Comment          from './components/Comment';
-import IdentifierList from './components/IdentifierList';
+import IdentifierList   from './components/IdentifierList';
 import StructDefinition from './components/StructDef';
 import VariableDefinition from './components/VariableDef';
 import FunctionDefinition from './components/FunctionDef';
+import Sequence         from './components/Sequence';
 
 export default class Renderer {
   constructor(cm, {lockNodesOfType=[], extraRenderers, printASTNode} = {}) {

--- a/src/ast.js
+++ b/src/ast.js
@@ -509,3 +509,27 @@ export class Blank extends ASTNode {
     return `${this.value}`;
   }
 }
+
+export class Sequence extends ASTNode {
+  constructor(from, to, exprs, name, options={}) {
+    super(from, to, 'sequence', options);
+    this.exprs = exprs;
+    this.name = name;
+  }
+
+  *[Symbol.iterator]() {
+    yield this;
+    for (let expr of this.exprs) {
+      yield expr;
+    }
+  }
+
+  toDescription(level) {
+    if((this['aria-level'] - level) >= descDepth) return this.options['aria-label'];
+    return `a sequence containing ${enumerateList(this.exprs)}`;
+  }
+
+  toString() {
+    return `(${this.name} ${this.exprs.join(" ")})`;
+  }
+}

--- a/src/components/Sequence.js
+++ b/src/components/Sequence.js
@@ -1,0 +1,36 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+import {Sequence as ASTSequenceNode} from '../ast';
+import Node from './Node';
+import DropTarget from './DropTarget';
+
+export default class Sequence extends Component {
+  static propTypes = {
+    node: PropTypes.instanceOf(ASTSequenceNode).isRequired,
+    helpers: PropTypes.shape({
+      renderNodeForReact: PropTypes.func.isRequired,
+    }).isRequired,
+    lockedTypes: PropTypes.instanceOf(Array).isRequired,
+  }
+
+  render() {
+    const {node, helpers, lockedTypes} = this.props;
+    const exprNodes = [];
+    node.exprs.forEach((expr, index) => {
+      exprNodes.push(helpers.renderNodeForReact(expr, 'node-'+index));
+      exprNodes.push(
+        <DropTarget location={expr.to} />
+      );
+    });
+    return (
+      <Node type="sequence" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+        <span className="blocks-operator">{node.name}</span>
+        <div className="blocks-sequence-exprs">
+          <DropTarget location={node.exprs.length ? node.exprs[0].from : node.to} />
+          {exprNodes}
+        </div>
+      </Node>
+    );
+  }
+}

--- a/src/languages/wescheme/WeschemeParser.js
+++ b/src/languages/wescheme/WeschemeParser.js
@@ -12,6 +12,7 @@ import {
   Comment,
   VariableDefinition,
   Unknown,
+  Sequence,
   Blank
 } from '../../ast';
 import {PrimitiveGroup} from '../../parsers/primitives';
@@ -266,11 +267,14 @@ function parseNode(node, i) {
                       , {'aria-label':aria, 'comment': comment});
   } else if (node instanceof structures.comment) {
     return new Comment(from, to, node.txt);
+  } else if (node instanceof structures.beginExpr) {
+    return new Sequence(from, to, node.exprs.map(parseNode), "begin",
+                       {'aria-label': `a sequence containing ${pluralize('expression', node.exprs)}`});
   } else if (node instanceof structures.unsupportedExpr) {
     if(node.val.constructor !== Array) return null;
     return new Unknown(from, to, node.val.map(parseNode).filter(item => item !== null),
                       {msg: node.errorMsg, 'aria-label': 'invalid expression'});
-  }
+  } 
   console.log("!! No translator for", node);
   return null;
 }

--- a/src/languages/wescheme/style.less
+++ b/src/languages/wescheme/style.less
@@ -26,6 +26,7 @@
   .blocks-expression,
   .blocks-ifExpression,
   .blocks-condExpression,
+  .blocks-sequence,
   .blocks-unknown {
     display: inline-flex;
     flex-direction: column;
@@ -48,6 +49,26 @@
 
   .blocks-lambdaExpression {
     border-radius: @large-border-radius @large-border-radius 0px 0px;
+  }
+
+  .blocks-sequence {
+    border-radius: 0px;
+    background: white;
+    > .blocks-operator {
+      justify-content: flex-start;
+    }
+    > .blocks-sequence-exprs {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      margin: 1px;
+
+      > .blocks-white-space {
+        display: block;
+        height: 16px;
+        border-width: 2px;
+      }
+    }
   }
 
   .blocks-condExpression,


### PR DESCRIPTION
Adds Sequence nodes to the block language and displays WeschemeParser `beginExprs` as Sequence nodes.

<img width="217" alt="screen shot 2017-12-19 at 3 16 55 pm" src="https://user-images.githubusercontent.com/13021310/34178648-f309b810-e4d5-11e7-9cc3-34212230d20c.png">

(having a little trouble getting the existing test suite to run, so tests are not yet available for the changes in this PR for now)