### PR TITLE
Optimization

### DIFF
--- a/example/editor-example.js
+++ b/example/editor-example.js
@@ -41,6 +41,7 @@ let editor = renderEditorInto(
 );
 editor.getCodeMirror().setValue(code);
 editor.getCodeMirror().setOption("lineNumbers", true);
+editor.getCodeMirror().setOption("viewportMargin", 10);
 editor.getCodeMirror().doc.clearHistory();
 
 ReactDOM.render((

--- a/example/fullscheme-example.js
+++ b/example/fullscheme-example.js
@@ -10,21 +10,23 @@ require('./example-page.less');
 
 var cm = CodeMirror.fromTextArea(
   document.getElementById("code"),
-  {theme:'3024-day',
-  lineNumbers: true,
-   autoCloseBrackets: true}
+  { theme:'3024-day',
+    lineNumbers: true,
+    autoCloseBrackets: true,
+    viewportMargin: 10}
 );
 
 var cm2 = CodeMirror.fromTextArea(
   document.getElementById('code2'),
-  {theme:'3024-day',
-   autoCloseBrackets: false,
-   lineNumbers: true,
-   extraKeys: {
-     "Shift-9" : function(cm){
-       cm.replaceSelection("(...)");
-     }
-   }
+  { theme:'3024-day',
+    autoCloseBrackets: false,
+    lineNumbers: true,
+    viewportMargin: 10,
+    extraKeys: {
+      "Shift-9" : function(cm) {
+        cm.replaceSelection("(...)");
+      }
+    }
  }
 );
 

--- a/example/wescheme-example.js
+++ b/example/wescheme-example.js
@@ -14,7 +14,7 @@ var cm = CodeMirror.fromTextArea(
 );
 var cm2 = CodeMirror.fromTextArea(
   document.getElementById('code2'),
-  {lineNumbers: true, theme:'3024-day'}
+  {lineNumbers: true, theme:'3024-day', viewportMargin: 10}
 );
 
 var focusCarousel = [cm, cm2, document.getElementById("mode")];

--- a/example/wescheme.html
+++ b/example/wescheme.html
@@ -98,6 +98,7 @@
           <tr><td>Collapse All</td>             <td><kbd>Shift-Right</kbd></td></tr>
           <tr><td>First Visible Block</td>      <td><kbd>Home</kbd></td></tr>
           <tr><td>Last Visible Block</td>       <td><kbd>End</kbd></td></tr>
+          <tr><td>Next/Prev Visible Block</td>   <td><kbd>Shift-PageUp</kbd>/<kbd>Shift-PageDown</kbd></td></tr>
           <tr><td>Read Ancestors</td>           <td><kbd aria-label="backslash">\</kbd></td></tr>
           <tr><td>Read Block and Children</td>  <td><kbd aria-label="shift-backslash">Shift-\</kbd></td></tr>
           </tbody>

--- a/spec/ast-test.js
+++ b/spec/ast-test.js
@@ -1,4 +1,5 @@
 import {AST, Literal, Expression, Sequence} from 'codemirror-blocks/ast';
+import WeschemeParser from 'codemirror-blocks/languages/wescheme/WeschemeParser';
 
 describe("The Literal Class", function() {
   it("should be constructed with a value and data type", function() {
@@ -183,3 +184,231 @@ describe("The AST Class", function() {
     expect(ast.nodeIdMap.get(nodes[1].args[1].id)).toBe(nodes[1].args[1]);
   });
 });
+
+/*
+describe("AST Patching", function() {
+  beforeEach(function() {
+    this.parser = new WeschemeParser();
+    this.ast = this.parser.parse('42\n\n(+ 1 (* 2 3))\n\n"hello"');
+  });
+
+  it('42 (+ 1 (* 2 3)) "hello" -> 41 (+ 1 (* 2 3)) "hello"', function() {
+    let newCode = '41\n\n(+ 1 (* 2 3))\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change = { from: {line: 0, ch:0}, to: {line:0, ch:2}, text: ["41"], removed: ["42"] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[0].value).toBe("41");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+  });
+
+  it('42 (+ 1 (* 2 3)) "hello" -> 41 (foo bar baz) "hello"', function() {
+    let newCode = '41\n\n(foo bar baz)\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change = { from: {line: 2, ch:0}, to: {line:2, ch:13}, text: ["(foo bar baz)"], removed: ["(+ 1 (* 2 3)))"] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[1].func.value).toBe("foo");
+    expect(this.ast.rootNodes[1].args.length).toBe(2);
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" --> 42  (foo bar baz)  ', function() {
+    let newCode = '42\n\n(+ 1 (* 1 2 3))\n\n';
+    var newAST = this.parser.parse(newCode);
+    let change = { from: {line: 4, ch:0}, to: {line:4, ch:7}, text: [""], removed: ['"hello"'] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change]);
+    expect(this.ast.rootNodes.length).toBe(2);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (+ 1 )  "hello"', function() {
+    var newCode = '42\n\n(+ 1 )\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change = { from: {line: 2, ch:5}, to: {line:2, ch:12}, text: [""], removed: ["(* 2 3)"] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[2].type).toBe("literal");
+    expect(this.ast.rootNodes[1].args.length).toBe(1);
+    expect(this.ast.rootNodes[1].args[0].value).toBe("1");
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> (+ 1 (* 2 3)) 42 "hello"', function() {
+    var newCode = '\n\n(+ 1 (* 2 3))\n42\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 3, ch:0}, to: {line:3, ch:0}, text: ["42"], removed: [""] };
+    let change2 = { from: {line: 0, ch:0}, to: {line:0, ch:2}, text: [""], removed: ["42"] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("expression");
+    expect(this.ast.rootNodes[1].type).toBe("literal");
+    expect(this.ast.rootNodes[2].type).toBe("literal");
+    expect(this.ast.rootNodes[1].value).toBe("42");
+    expect(this.ast.rootNodes[2].value).toBe('"hello"');
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42 "hello" (+ 1 (* 2 3))', function() {
+    var newCode = '42\n"hello"\n(+ 1 (* 3 2))\n\n';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 4, ch:0}, to: {line:4, ch:7}, text: [""], removed: ['"hello"'] };
+    let change2 = { from: {line: 1, ch:0}, to: {line:1, ch:0}, text: ['"hello"'], removed: [""] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].value).toBe("42");
+    expect(this.ast.rootNodes[1].value).toBe('"hello"');
+    expect(this.ast.rootNodes[2].type).toBe("expression");
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (+ 1 (* 3 2))  "hello"', function() {
+    var newCode = '42\n\n(+ 1 (* 3 2))\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 2, ch:10}, to: {line:2, ch:11}, text: [""], removed: ["3"] };
+    let change2 = { from: {line: 2, ch:8}, to: {line:2, ch:8}, text: ["3 "], removed: [""] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[1].args.length).toBe(2);
+    expect(this.ast.rootNodes[1].args[1].args[0].value).toBe("3");
+    expect(this.ast.rootNodes[1].args[1].args[1].value).toBe("2");
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (+ (* 2 3) 1)  "hello"', function() {
+    var newCode = '42\n\n(+ (* 2 3) 1)\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 2, ch:7}, to: {line:2, ch:14}, text: [""], removed: ["(* 2 3)"] };
+    let change2 = { from: {line: 2, ch:3}, to: {line:2, ch:3}, text: ["(* 2 3)"], removed: [""] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[1].args.length).toBe(2);
+    expect(this.ast.rootNodes[1].args[0].type).toBe("expression");
+    expect(this.ast.rootNodes[1].args[1].type).toBe("literal");
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (+ 1 2 (* 3))  "hello"', function() {
+    var newCode = '42\n\n(+ 1 2 (* 3))\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 2, ch:8}, to: {line:2, ch:9}, text: [""], removed: ["2"] };
+    let change2 = { from: {line: 2, ch:4}, to: {line:2, ch:4}, text: [" 2"], removed: [""] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[1].args.length).toBe(3);
+    expect(this.ast.rootNodes[1].args[0].value).toBe("1");
+    expect(this.ast.rootNodes[1].args[1].value).toBe("2");
+    expect(this.ast.rootNodes[1].args[2].type).toBe("expression");
+    expect(this.ast.rootNodes[1].args[2].args[0].value).toBe("3");
+    expect(this.ast.rootNodes[1].args[2].args.length).toBe(1);
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (+ (* 1 2 3))  "hello"', function() {
+    var newCode = '42\n\n(+  (* 1 2 3))\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 2, ch:8}, to: {line:2, ch:8}, text: ["1 "], removed: [""] };
+    let change2 = { from: {line: 2, ch:4}, to: {line:2, ch:13}, text: [""], removed: ["1"] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[1].args.length).toBe(1);
+    expect(this.ast.rootNodes[1].args[0].type).toBe("expression");
+    expect(this.ast.rootNodes[1].args[0].args[0].value).toBe("1");
+    expect(this.ast.rootNodes[1].args[0].args.length).toBe(3);
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (+ 1 ) (* 2 3)  "hello"', function() {
+    var newCode = '42\n\n(+ 1 ) (* 2 3)\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 2, ch:13}, to: {line:2, ch:13}, text: [" (* 2 3)"], removed: [""] };
+    let change2 = { from: {line: 2, ch:5}, to: {line:2, ch:12}, text: [""], removed: ["(* 2 3)"] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(4);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[2].type).toBe("expression");
+    expect(this.ast.rootNodes[3].type).toBe("literal");
+    expect(this.ast.rootNodes[1].args.length).toBe(1);
+    expect(this.ast.rootNodes[1].func.value).toBe("+");
+    expect(this.ast.rootNodes[2].args.length).toBe(2);
+    expect(this.ast.rootNodes[2].func.value).toBe("*");
+    expect(this.ast.rootNodes[3].value).toBe('"hello"');
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (* 2 3) (+ 1 )  "hello"', function() {
+    var newCode = '42\n\n(* 2 3) (+ 1 )\n\n"hello"';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 2, ch:5}, to: {line:2, ch:12}, text: [""], removed: ["(* 2 3)"] };
+    let change2 = { from: {line: 2, ch:0, sticky: "after"}, to: {line:2, ch:0, sticky: "after"}, text: ["(* 2 3) "], removed: [""] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(4);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[2].type).toBe("expression");
+    expect(this.ast.rootNodes[3].type).toBe("literal");
+    expect(this.ast.rootNodes[1].args.length).toBe(2);
+    expect(this.ast.rootNodes[1].func.value).toBe("*");
+    expect(this.ast.rootNodes[2].args.length).toBe(1);
+    expect(this.ast.rootNodes[2].func.value).toBe("+");
+    expect(this.ast.rootNodes[3].value).toBe('"hello"');
+  });
+
+  it('(+ 1 (* 3 5 (- 2 9))) -> (+ (* 3 5 (- 1 2 9)))', function() {
+    this.ast = this.parser.parse('(+ 1 (* 3 5 (- 2 9)))');
+    var newCode = '(+ (* 3 5 (- 1 2 9)))';
+    var newAST = this.parser.parse(newCode);
+    let change1 = { from: {line: 0, ch:15}, to: {line:0, ch:15}, text: ["1 "], removed: [""] };
+    let change2 = { from: {line: 0, ch:4}, to: {line:0, ch:21}, text: [""], removed: ["1"] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(1);
+    expect(this.ast.rootNodes[0].type).toBe("expression");
+    expect(this.ast.rootNodes[0].args.length).toBe(1);
+    expect(this.ast.rootNodes[0].args[0].type).toBe("expression");
+    expect(this.ast.rootNodes[0].args[0].args.length).toBe(3);
+    expect(this.ast.rootNodes[0].args[0].args[2].type).toBe("expression");
+    expect(this.ast.rootNodes[0].args[0].args[2].args.length).toBe(3);
+    expect(this.ast.rootNodes[0].args[0].args[2].args[0].value).toBe("1");
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" -> 42  (+ 1 (* 2 3))  ', function() {
+    var newCode = '42\n\n(+ 1 ) (* 2 3)\n\n';
+    let change1 = { from: {line: 4, ch:0}, to: {line:4, ch:7}, text: [""], removed: ['"hello"'] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1]);
+    expect(this.ast.rootNodes.length).toBe(2);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+  });
+
+  it('42  (+ 1 (* 2 3))  "hello" ->   (+ 1 (* 2 3))  "hello"', function() {
+    var newCode = '\n\n(+ 1 ) (* 2 3)\n\n"hello"';
+    let change1 = { from: {line: 0, ch:0}, to: {line:0, ch:2}, text: [""], removed: ['42'] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1]);
+    expect(this.ast.rootNodes.length).toBe(2);
+    expect(this.ast.rootNodes[0].type).toBe("expression");
+    expect(this.ast.rootNodes[1].type).toBe("literal");
+  });
+
+  it('42  (+ 1 (* 2 3)) moo  "hello" ->   (+ 1 (* 2 3 moo))  "hello"', function() {
+    this.ast = this.parser.parse('42\n\n(+ 1 (* 2 3)) moo\n\n"hello"');
+    var newCode = '42\n\n(+ 1 (* 2 3) moo) \n\n"hello"';
+    let change1 = { from: {line: 2, ch:14}, to: {line:2, ch:17}, text: [""], removed: ["moo"] };
+    let change2 = { from: {line: 2, ch:12}, to: {line:2, ch:12}, text: ["moo"], removed: [""] };
+    this.ast = this.ast.patch(this.parser.parse, newCode, [change1, change2]);
+    expect(this.ast.rootNodes.length).toBe(3);
+    expect(this.ast.rootNodes[0].type).toBe("literal");
+    expect(this.ast.rootNodes[1].type).toBe("expression");
+    expect(this.ast.rootNodes[2].type).toBe("literal");
+    expect(this.ast.rootNodes[1].args.length).toBe(3);
+    expect(this.ast.rootNodes[1].args[2].type).toBe("literal");
+    expect(this.ast.rootNodes[1].args[2].value).toBe("moo");
+    expect(this.ast.rootNodes[2].value).toBe('"hello"');
+  });
+});
+*/

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -99,7 +99,7 @@ export default class Renderer {
     function flatten(flat, node) {
       return ["literal", "blank"].includes(node.type)? flat.concat([node])  // nothing inside literals and blanks
           : that.lockNodesOfType.includes(node.type)? flat.concat([node])   // Perf: don't bother looking inside
-          : [...node].slice(1).reduce(flatten, flat);                       // look inside
+            : [...node].slice(1).reduce(flatten, flat);                      // look inside
     }
 
     // 1) Limit the number of lines CM is rendering (perf), and extract visible nodes, & make clones 
@@ -142,19 +142,25 @@ export default class Renderer {
   }
 
   // Render the rootNode into a new marker, clearing any old ones
-  render(rootNode, quarantine=false) {
-    var marker = this.cm.findMarksAt(rootNode.from).filter(m => m.node)[0];
-    // recycle the container, if we can
-    let container = (marker && !quarantine)? marker.replacedWith : document.createElement('span');
-    if(marker && !quarantine) marker.clear();
-    this.cm.markText(rootNode.from, rootNode.to, {replacedWith: container, node: rootNode} );
-    
-    // REVISIT: make comments disappear by adding an empty span
-    if(rootNode.options.comment) {
-      this.cm.markText(rootNode.options.comment.from, rootNode.options.comment.to,
-        { replacedWith: document.createElement('span') });
+  // Render the node, recycling a container whenever possible
+  render(node, quarantine=false) {
+    var container;
+    if(node["aria-level"] == 1) { // if it's a root node, reset the marker but save the container
+      let marker = this.cm.findMarksAt(node.from).filter(m => m.node)[0];
+      // recycle the container, if we can
+      container = (marker && !quarantine)? marker.replacedWith : document.createElement('span');
+      if(marker && !quarantine) marker.clear();
+      this.cm.markText(node.from, node.to, {replacedWith: container, node: node} );
+      
+      // REVISIT: make comments disappear by adding an empty span
+      if(node.options.comment) {
+        this.cm.markText(node.options.comment.from, node.options.comment.to,
+          { replacedWith: document.createElement('span') });
+      }
+    } else { // otherwise just render in-place
+      container = node.el.parentNode;
     }
-    ReactDOM.render(this.renderNodeForReact(rootNode), container);
+    ReactDOM.render(this.renderNodeForReact(node), container);
     container.className = 'react-container';
     return container;
   }

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -142,25 +142,19 @@ export default class Renderer {
   }
 
   // Render the rootNode into a new marker, clearing any old ones
-  // Render the node, recycling a container whenever possible
-  render(node, quarantine=false) {
-    var container;
-    if(node["aria-level"] == 1) { // if it's a root node, reset the marker but save the container
-      let marker = this.cm.findMarksAt(node.from).filter(m => m.node)[0];
-      // recycle the container, if we can
-      container = (marker && !quarantine)? marker.replacedWith : document.createElement('span');
-      if(marker && !quarantine) marker.clear();
-      this.cm.markText(node.from, node.to, {replacedWith: container, node: node} );
-      
-      // REVISIT: make comments disappear by adding an empty span
-      if(node.options.comment) {
-        this.cm.markText(node.options.comment.from, node.options.comment.to,
-          { replacedWith: document.createElement('span') });
-      }
-    } else { // otherwise just render in-place
-      container = node.el.parentNode;
+  render(rootNode, quarantine=false) {
+    var marker = this.cm.findMarksAt(rootNode.from).filter(m => m.node)[0];
+    // recycle the container, if we can
+    let container = (marker && !quarantine)? marker.replacedWith : document.createElement('span');
+    if(marker && !quarantine) marker.clear();
+    this.cm.markText(rootNode.from, rootNode.to, {replacedWith: container, node: rootNode} );
+    
+    // REVISIT: make comments disappear by adding an empty span
+    if(rootNode.options.comment) {
+      this.cm.markText(rootNode.options.comment.from, rootNode.options.comment.to,
+        { replacedWith: document.createElement('span') });
     }
-    ReactDOM.render(this.renderNodeForReact(node), container);
+    ReactDOM.render(this.renderNodeForReact(rootNode), container);
     container.className = 'react-container';
     return container;
   }

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -502,7 +502,7 @@ export default class CodeMirrorBlocks {
       let errorTxt = this.parser.getExceptionMessage(e);
       nodeEl.title = errorTxt;                        // 4) Make the title the error msg
       setTimeout(()=>this.editLiteral(node,event),50);// 5) Keep focus
-      this.say("Error: "+errorTxt);
+      this.say(errorTxt);
     }
   }
 

--- a/src/components/Blank.js
+++ b/src/components/Blank.js
@@ -15,7 +15,7 @@ export default class Literal extends Component {
   render() {
     const {node, lockedTypes, helpers} = this.props;
     return (
-      <Node type="literal" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className={`blocks-literal-symbol`}>
         ...
         </span>

--- a/src/components/CondClause.js
+++ b/src/components/CondClause.js
@@ -17,7 +17,7 @@ export default class CondClause extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="condClause" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <div className="blocks-cond-row">
           <div className="blocks-cond-predicate">
             <DropTarget location={node.testExpr.from} />

--- a/src/components/CondExpression.js
+++ b/src/components/CondExpression.js
@@ -16,7 +16,7 @@ export default class CondExpression extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="condExpression" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">cond</span>
         <div className="blocks-cond-table">
           {node.clauses.map((clause, index) => helpers.renderNodeForReact(clause, index)) }

--- a/src/components/Expression.js
+++ b/src/components/Expression.js
@@ -22,7 +22,7 @@ export default class Expression extends Component {
       argNodes.push(<DropTarget location={arg.to} key={'drop-'+index} />);
     });
     return (
-      <Node type="expression" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">
           <DropTarget location={node.func.from} />
           {helpers.renderNodeForReact(node.func)}

--- a/src/components/FunctionDef.js
+++ b/src/components/FunctionDef.js
@@ -17,7 +17,7 @@ export default class FunctionDefinition extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="functionDef" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">
           define (
           <DropTarget location={node.name.from} />

--- a/src/components/IdentifierList.js
+++ b/src/components/IdentifierList.js
@@ -22,7 +22,7 @@ export default class IdentifierList extends Component {
       idNodes.push(<DropTarget location={id.to} key={'drop-'+index} />);
     });
     return (
-      <Node type="identifierlist" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-args">
           <DropTarget location={node.ids[0].from} />
           {idNodes}

--- a/src/components/IfExpression.js
+++ b/src/components/IfExpression.js
@@ -17,7 +17,7 @@ export default class IfExpression extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="ifExpression" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">if</span>
         <div className="blocks-cond-table">
           <div className="blocks-cond-row">

--- a/src/components/LambdaExpression.js
+++ b/src/components/LambdaExpression.js
@@ -16,7 +16,7 @@ export default class LambdaExpression extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="lambdaExpression" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">
           &lambda; (
           {helpers.renderNodeForReact(node.args)}

--- a/src/components/Literal.js
+++ b/src/components/Literal.js
@@ -15,7 +15,7 @@ export default class Literal extends Component {
   render() {
     const {node, lockedTypes, helpers} = this.props;
     return (
-      <Node type="literal" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className={`blocks-literal-${node.dataType}`}>
           {node.value.toString()}
         </span>

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -5,7 +5,6 @@ import {ASTNode} from '../ast';
 
 export default class Node extends PureComponent {
   static propTypes = {
-    type: PropTypes.string.isRequired,
     node: PropTypes.instanceOf(ASTNode),
     children: PropTypes.node.isRequired,
     helpers: PropTypes.shape({
@@ -15,11 +14,11 @@ export default class Node extends PureComponent {
   }
 
   render() {
-    const {type, node, lockedTypes=[], helpers, children} = this.props;
-    let locked = lockedTypes.includes(type);
+    const {node, lockedTypes=[], helpers, children} = this.props;
+    let locked = lockedTypes.includes(node.type);
     // blanks, comments, and literals, can't be expanded.
     let expandable = !["blank", "comment", "literal"].includes(node.type);
-    let classes = `blocks-node blocks-${type} ` + (locked? "blocks-locked" : "");
+    let classes = `blocks-node blocks-${node.type} ` + (locked? "blocks-locked" : "");
     if(node.options.comment){
       node.options.comment.id = "block-node-"+node.id+"-comment";
     }

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -33,7 +33,7 @@ export default class Node extends PureComponent {
         aria-label      = { node.options['aria-label'] }
         aria-describedby= { node.options.comment? `block-node-${node.options.comment.id}`: undefined}
         aria-disabled   = { locked? "true": undefined }
-        aria-expanded   = { expandable? (node.collapsed ? "false" : "true") : undefined}
+        aria-expanded   = { expandable? ((locked || node.collapsed )? "false" : "true") : undefined}
         aria-setsize    = { node["aria-setsize"]  }
         aria-posinset   = { node["aria-posinset"] }
         aria-level      = { node["aria-level"]    }

--- a/src/components/Sequence.js
+++ b/src/components/Sequence.js
@@ -24,7 +24,7 @@ export default class Sequence extends Component {
       );
     });
     return (
-      <Node type="sequence" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">{node.name}</span>
         <div className="blocks-sequence-exprs">
           <DropTarget location={node.exprs.length ? node.exprs[0].from : node.to} />

--- a/src/components/StructDef.js
+++ b/src/components/StructDef.js
@@ -17,7 +17,7 @@ export default class StructDefinition extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="struct" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">
           define-struct 
           <DropTarget location={node.name.from} />

--- a/src/components/Unknown.js
+++ b/src/components/Unknown.js
@@ -24,7 +24,7 @@ export default class Unknown extends Component {
       childNodes.push(<DropTarget location={arg.to} key={'drop-'+index} />);
     });
     return (
-      <Node type="unknown" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">{helpers.renderNodeForReact(firstElt)}</span>
         <span className="blocks-args">
           <DropTarget location={restElts.length ? firstElt.from : firstElt.to} />

--- a/src/components/VariableDef.js
+++ b/src/components/VariableDef.js
@@ -17,7 +17,7 @@ export default class VariableDefinition extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="variableDef" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">
           define 
           <DropTarget location={node.name.from} />

--- a/src/languages/wescheme/components/LetLikeExpr.js
+++ b/src/languages/wescheme/components/LetLikeExpr.js
@@ -16,7 +16,7 @@ export default class LetLikeExpr extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="letLikeExpr" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">{node.form}</span>
         {helpers.renderNodeForReact(node.bindings)}
         {helpers.renderNodeForReact(node.expr)}

--- a/src/languages/wescheme/components/WhenUnlessExpr.js
+++ b/src/languages/wescheme/components/WhenUnlessExpr.js
@@ -16,7 +16,7 @@ export default class WhenUnlessExpr extends Component {
   render() {
     const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node type="whenUnlessExpr" node={node} lockedTypes={lockedTypes} helpers={helpers}>
+      <Node node={node} lockedTypes={lockedTypes} helpers={helpers}>
         <span className="blocks-operator">{node.form}</span>
         {helpers.renderNodeForReact(node.predicate)}
         {helpers.renderNodeForReact(node.exprs)}

--- a/src/languages/wescheme/style.less
+++ b/src/languages/wescheme/style.less
@@ -19,10 +19,10 @@
 
   .react-container{ position: relative; }
 
-  .blocks-struct,
-  .blocks-functionDef,
+  .blocks-structDefinition,
+  .blocks-functionDefinition,
   .blocks-lambdaExpression,
-  .blocks-variableDef,
+  .blocks-variableDefinition,
   .blocks-expression,
   .blocks-ifExpression,
   .blocks-condExpression,
@@ -145,7 +145,7 @@
     > .blocks-node {
       box-shadow: 0px 0px 10px 1px white;
     }
-    .blocks-literal, .blocks-identifierlist {
+    .blocks-literal, .blocks-identifierList {
       color: white;
       box-shadow: none;
     }
@@ -239,7 +239,7 @@
     border-color: @editing-border-color;
     outline: 0;
   }
-  .blocks-identifierlist:focus{
+  .blocks-identifierList:focus{
     border-style: none;
     background: @editing-border-color;
     border-radius: 15px;
@@ -379,7 +379,7 @@
       text-align: left;
     }
   }
-  .blocks-node[aria-expanded="true"] .blocks-identifierlist[aria-expanded="false"]:before{
+  .blocks-node[aria-expanded="true"] .blocks-identifierList[aria-expanded="false"]:before{
       content: "...";
       color: white;
   }

--- a/src/less/blocks.less
+++ b/src/less/blocks.less
@@ -1,22 +1,35 @@
-
-.blocks-node{ 
-  animation-duration: 1s; 
+.CodeMirror-lines.fadein, .fadein .blocks-node{
+  animation-name: fadein;
+  animation-duration: 1.5s; 
+}
+.fadeout{
+  animation-name: fadeout;
+  animation-duration: 1.5s; 
 }
 #clones * { 
   display:  inline-block;
   position: absolute;
-  will-change: transform; 
+  will-change: transform;
+  transform-origin: top left;
 }
-#clones .box{ border: dotted 1px lightgray; border-radius: 15px; }
-#clones.animate * { transition: all 1s linear; transform: none !important;}
+#clones .box{ border: dashed 1px gray; border-radius: 15px; color: transparent;}
+#clones.animate * { transition: transform 1.0s linear; transform: none !important;}
+#clones.animate.blocks .literal {margin-left: 4px;}
 
 @keyframes fadein {
     0% { opacity: 0; }
    50% { opacity: 0; }
+   70% { opacity: 0; }
   100% { opacity: 1; }
 }
 @keyframes fadeout {
     0% { opacity: 1; }
-   50% { opacity: 1; }
+   50% { opacity: 0; }
+   70% { opacity: 0; }
   100% { opacity: 0; }
+}
+
+/* locked and collapsed nodes should not be editable */
+.blocks-node[aria-expanded="false"] *, .blocks-locked * { 
+  pointer-events : none; cursor: hand;
 }


### PR DESCRIPTION
Move over the non-patching improvements from the speed branch.
- Use CM's viewport
- Improvements to `render()`, allowing it to handle non-root nodes
- Use `node.type` to derive className in React Components, eliminating the need to pass around `type` as an argument
- Improvements to `animateTransition()`