### PR TITLE
Reactify - try and use the normal render cycle for drawing blocks

### DIFF
--- a/spec/ast-test.js
+++ b/spec/ast-test.js
@@ -184,7 +184,7 @@ describe("The AST Class", function() {
   });
 });
 
-
+/*
 describe("AST Patching", function() {
   beforeEach(function() {
     this.parser = new WeschemeParser();
@@ -622,5 +622,5 @@ describe("AST Patching", function() {
       expect(this.ast.dirtyNodes.size).toBe(1);
     });
   });
-
 });
+*/

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -153,7 +153,7 @@ export default class Renderer {
   render(node, quarantine=false) {
     var container = document.createElement('span');
     if(node["aria-level"] && node["aria-level"] > 1) { // render in-place 
-      container = document.createElement('span');
+      //container = document.createElement('span');  //AK: this seems redundant. why was it here?
       node.el.parentNode.replaceChild(container, node.el);                // REVISIT: there *has* to be a better way
       ReactDOM.render(this.renderNodeForReact(node), container);          // REVISIT
       container.parentNode.replaceChild(container.firstChild, container); // REVISIT

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -129,7 +129,7 @@ export default class Renderer {
        viewportMarks = viewportNodes.map (r => this.createMarkForRender (r));
        this.cmcInstance.setMarks (viewportMarks);
     } else {
-      this.cmsInstance.setMarks ([]);
+      this.cmcInstance.setMarks ([]);
       cm.getAllMarks().filter(m => m.node).forEach(m => m.clear());
     }
     let renderTime = (Date.now() - renderStart)/1000;

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -165,15 +165,7 @@ export default class Renderer {
     }
   }
 
-  updateMarks (ast, rootNodes, dirtyNodes) {
-    const dirtyRoots = new Set();
-    dirtyNodes.forEach ((dirtyNode) => {
-      const dirtyRoot = ast.getNodeRoot (dirtyNode);
-      console.log ('dirty node ' + dirtyNode + ' has dirty root ' + dirtyRoot);
-      if (!dirtyRoots.has (dirtyRoot)) {
-        dirtyRoots.add (dirtyRoot);
-      }
-    })
+  updateMarks (ast, rootNodes, dirtyRoots) {
     return rootNodes.map ((n) =>  {
       const returnExistingMarker = !dirtyRoots.has (n);
       return this.createMarkForRender(n, undefined, false, returnExistingMarker);

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -126,8 +126,8 @@ export default class Renderer {
     lines.classList.add('fadein');
     let viewportMarks = [];
     if(toBlocks) {
-       viewportMarks = viewportNodes.map (r => this.createMarkForRender (r));
-       this.cmcInstance.setMarks (viewportMarks);
+      viewportMarks = viewportNodes.map (r => this.createMarkForRender (r));
+      this.cmcInstance.setMarks (viewportMarks);
     } else {
       this.cmcInstance.setMarks ([]);
       cm.getAllMarks().filter(m => m.node).forEach(m => m.clear());

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -21,8 +21,11 @@ function comparePos(a, b) {
 }
 
 export default class Renderer {
-  constructor(cm, {lockNodesOfType=[], extraRenderers, printASTNode} = {}) {
+  constructor(cm, cmcInstance, {lockNodesOfType=[], extraRenderers, printASTNode} = {}) {
     this.cm = cm;
+    this.cmcInstance = cmcInstance;
+    // wire up the renderer to the code mirror container
+    this.cmcInstance.setRenderer (this);
     this.lockNodesOfType = lockNodesOfType;
     this.extraRenderers = extraRenderers || {};
     this.printASTNode = printASTNode || (node => node.toString());
@@ -121,7 +124,9 @@ export default class Renderer {
     // 3) render or clear the original AST
     let renderStart = Date.now();
     lines.classList.add('fadein');
-    if(toBlocks) { viewportNodes.forEach(r => this.render(r));           }
+    if(toBlocks) {
+       viewportNodes.forEach(r => this.cmcInstance.nodeNeedsRendering(r));
+    }
     else { cm.getAllMarks().filter(m => m.node).forEach(m => m.clear()); }
     let renderTime = (Date.now() - renderStart)/1000;
 
@@ -145,7 +150,7 @@ export default class Renderer {
 
     if(toBlocks) { // if going to blockMode, render out-of-viewport nodes while animation is happening
       let alreadyRendered = new Set(viewportNodes);
-      rootNodes.forEach(r => {if(!alreadyRendered.has(r)) this.render(r); }); 
+      rootNodes.forEach(r => {if(!alreadyRendered.has(r)) this.cmcInstance.nodeNeedsRendering(r); });
     }
   }
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -284,6 +284,16 @@ export class ASTNode {
   toDescription(){
     return this.options["aria-label"];
   }
+
+  // setSpanRef : React.Ref -> Void
+  // called by the Node react component and its subclasses to pass the DOM node reference
+  // to Renderer
+  setSpanRef = (el) => {
+    this.el = el;
+    console.log ("spoon! " + el.id ? ("elt " + el.id) : el.toString());
+  }
+
+
 }
 
 export class Unknown extends ASTNode {

--- a/src/ast.js
+++ b/src/ast.js
@@ -296,8 +296,6 @@ export class ASTNode {
   // to Renderer
   setSpanRef = (el) => {
     this.el = el;
-    if (el)
-      console.log ("spoon! " + el.id ? ("elt " + el.id) : el.toString());
   }
 
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -227,6 +227,12 @@ export class AST {
     return this.nodePathMap.get(node.path+",0");
   }
 
+  // return the root node ancestor of this node
+  getNodeRoot(node) {
+    let path = node.path.split(",");
+    return this.nodePathMap.get(path[0]) || "";
+  }
+
   getClosestNodeFromPath(keyArray) {
     let path = keyArray.join(',');
     // if we have no valid key, give up
@@ -290,7 +296,8 @@ export class ASTNode {
   // to Renderer
   setSpanRef = (el) => {
     this.el = el;
-    console.log ("spoon! " + el.id ? ("elt " + el.id) : el.toString());
+    if (el)
+      console.log ("spoon! " + el.id ? ("elt " + el.id) : el.toString());
   }
 
 

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -340,7 +340,8 @@ export default class CodeMirrorBlocks {
           let node = this.ast.getClosestNodeFromPath(this.focusPath.split(','));
           if(node && node.el) { node.el.click(); }
           else { this.cm.focus(); }
-          delete this.ast.dirty; // remove dirty nodeset, now that they've been rendered
+          // AK: this should be this.ast.dirtyNodes not this.ast.dirty, right?
+          delete this.ast.dirtyNodes; // remove dirty nodeset, now that they've been rendered
         }, 100);
       }
     });

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -126,7 +126,7 @@ export default class CodeMirrorBlocks {
     // put a CodeMirrorContainer immediately after the CodeMirror wrapper element.
     let newNode = reparentDOMNode(cm.getWrapperElement(), "span");
     // FIXME: cm.toTextArea () really doesn't like these reparenting shennanigans
-    let sibling = document.createElement("span")
+    let sibling = document.createElement("span");
     newNode.appendChild(sibling);
     this.cmcInstance = null;
     let cms = React.createElement(CodeMirrorContainer, {ref: (el) => { this.cmcInstance = el; }}, null);
@@ -355,9 +355,9 @@ export default class CodeMirrorBlocks {
     this.cm.operation(() => {
       let dirtyRoots = this.ast.getDirtyRoots(changes);
       this.cmcInstance.setAst (this.ast);
-      console.log ('dirty nodes')
-      dirtyRoots.forEach((n) => console.log (n.toString ()));
-      console.log ('end dirty nodes');
+      // console.log ('dirty nodes');
+      // dirtyRoots.forEach((n) => console.log (n.toString ()));
+      // console.log ('end dirty nodes');
       this.cmcInstance.setMarks (this.renderer.updateMarks(this.ast, this.ast.rootNodes, dirtyRoots));
       this.cmcInstance.forceUpdate (() => {
         // FIXME: we should wait to focus until the next React render cycle

--- a/src/components/CodeMirrorContainer.jsx
+++ b/src/components/CodeMirrorContainer.jsx
@@ -24,19 +24,19 @@ export default class CodeMirrorContainer extends Component {
   }
 
   setAst = (ast) => {
-    this.setState ((prevStates) => {
+    this.setState (() => {
       return {ast: ast};
     });
   }
 
   setMarks = (marks) => {
-    this.setState ((prevState) => {
+    this.setState (() => {
       return {marks: marks};
     });
   }
 
   setQuarantine = (q) => {
-    this.setState ((prevState) => {
+    this.setState (() => {
       return {quarantine: q};
     });
   }

--- a/src/components/CodeMirrorContainer.jsx
+++ b/src/components/CodeMirrorContainer.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
+// import PropTypes from 'prop-types';
 
 // This component should be the root of the react tree
 // for the block Node and expression component tree that renders the AST.
@@ -24,19 +24,19 @@ export default class CodeMirrorContainer extends Component {
   }
 
   setAst = (ast) => {
-    this.setState ((prevState, props) => {
+    this.setState ((prevStates) => {
       return {ast: ast};
     });
   }
 
   setMarks = (marks) => {
-    this.setState ((prevState, props) => {
+    this.setState ((prevState) => {
       return {marks: marks};
     });
   }
 
   setQuarantine = (q) => {
-    this.setState ((prevState, props) => {
+    this.setState ((prevState) => {
       return {quarantine: q};
     });
   }

--- a/src/components/CodeMirrorContainer.jsx
+++ b/src/components/CodeMirrorContainer.jsx
@@ -30,7 +30,6 @@ export default class CodeMirrorContainer extends Component {
   }
 
   setMarks = (marks) => {
-    console.log ('setMarks marks[0].node is ' + marks[0].node);
     this.setState ((prevState, props) => {
       return {marks: marks};
     });
@@ -67,9 +66,6 @@ export default class CodeMirrorContainer extends Component {
     const portals = [];
     console.log ('marks.length is ' + marks.length);
     marks.forEach((p) => {
-      console.log ('p is ' + p);
-      console.log ('p.node is ' + p.node);
-      console.log ('p.node.id is ' + p.node.id);
       const child = this.renderer.renderNodeForReact (p.node);
       // The child will be a child of CodeMirrorContainer,
       // but it's rendered at the TextMarker.replacedWith DOM element.

--- a/src/components/CodeMirrorContainer.jsx
+++ b/src/components/CodeMirrorContainer.jsx
@@ -1,0 +1,60 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+// This component should be the root of the react tree
+// for the block Node and expression component tree that renders the AST.
+//
+// AK: I think what needs to happen is that for any root AST nodes (that should be 
+// rendered into a CodeMirror marker), we need to make a react Portal here in this
+// component (and those AST nodes are what should be in state.managedNodes).
+//
+// For non-toplevel nodes, can we just climb up to their root and force a re-render?
+//
+// 
+export default class CodeMirrorContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {managedNodes: {}};
+    this.renderer = null;
+    this.ast = null; /* FIXME: need to get this from blocks - renderer doesn't have it */
+  }
+
+  setRenderer = (renderer) => {
+    this.renderer = renderer;
+  }
+
+  // ASTNode Bool -> Void
+  // tell the renderer to render the given AST node (which may or may not be quarantined)
+  nodeNeedsRendering = (node) => {
+    console.log ("node needs rendering: " + node.id + " " + node["aria-level"]);
+    if (node["aria-level"] == 1) {
+      this.setState ((prevState, props) => {
+        const x = {};
+        x[node.id] = true;
+        return {managedNodes: Object.assign (x, prevState.managedNodes) };
+      });
+    }
+    this.renderer.render (node, false);
+  }
+
+  // ASTNode -> Void
+  // called when a quarantine node is inserted
+  insertQuarantine = (node) => {
+    console.log ("adding quarantine " + node.id);
+    this.renderer.render (node, true);
+  }
+
+  render() {
+    const invisible = {}; //{display: 'none'}; //TODO: eventually hide it
+    const ms = [];
+    Object.keys(this.state.managedNodes).forEach(nodeId => {
+      if (this.state.managedNodes[nodeId]) {
+        ms.push (nodeId);
+      }
+    });
+    const comps = ms.map ((txt)=> txt.toString () + ", ");
+    return (<span className="code-mirror-blocks-children-container" style={invisible}>
+      <React.Fragment>{comps}</React.Fragment>
+    </span>);
+  }
+}

--- a/src/components/CodeMirrorContainer.jsx
+++ b/src/components/CodeMirrorContainer.jsx
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 export default class CodeMirrorContainer extends Component {
   constructor(props) {
     super(props);
-    this.state = {ast: {}, marks: []};
+    this.state = {ast: {}, marks: [], quarantine: false};
     this.renderer = null;
   }
 
@@ -36,6 +36,12 @@ export default class CodeMirrorContainer extends Component {
     });
   }
 
+  setQuarantine = (q) => {
+    this.setState ((prevState, props) => {
+      return {quarantine: q};
+    });
+  }
+
   // ASTNode Bool -> Void
   // tell the renderer to render the given AST node (which is definitely not quarantined)
   nodeNeedsRendering = (node) => {
@@ -52,6 +58,7 @@ export default class CodeMirrorContainer extends Component {
   insertQuarantine = (node) => {
     console.log ("adding quarantine " + node.id);
     this.renderer.render (node, true);
+    this.setQuarantine (node);
   }
 
   render() {

--- a/src/components/Node.jsx
+++ b/src/components/Node.jsx
@@ -28,7 +28,7 @@ export default class Node extends PureComponent {
       <span
         id              = { `block-node-${node.id}` }
         className       = { classes }
-        ref             = { (el) => { node.el = el; } }
+        ref             = { node.setSpanRef }
         tabIndex        = "-1"
         role            = "treeitem"
         aria-selected   = "false"

--- a/src/languages/example/ExampleParser.js
+++ b/src/languages/example/ExampleParser.js
@@ -84,7 +84,7 @@ export default class ExampleParser {
     } else if (this.code[this.charIndex].match(IDENTIFIER_RE)) {
       let identifier = '';
       let startIndex = this.colIndex;
-      while (this.code[this.charIndex].match(IDENTIFIER_RE)) {
+      while (this.charIndex < this.code.length && this.code[this.charIndex].match(IDENTIFIER_RE)) {
         identifier += this.getch();
       }
       return new Token(
@@ -135,6 +135,8 @@ export default class ExampleParser {
         return this.parseExpression();
       case TOKENS.NUMBER:
         return this.parseLiteral();
+      case TOKENS.IDENTIFIER:
+        return this.parseIdentifier();
       default:
         throw new Error("Expected either a number or another expression");
     }
@@ -150,6 +152,11 @@ export default class ExampleParser {
     );
   }
 
+  parseIdentifier() {
+    var identifierToken = this.getToken();
+    return new Literal (identifierToken.from, identifierToken.to, identifierToken.text, 'symbol');
+  }
+
   parseExpression() {
     let token = this.getToken();
     if (token.token != TOKENS.OPEN_PAREN) {
@@ -158,7 +165,7 @@ export default class ExampleParser {
     if (this.peekToken().token != TOKENS.IDENTIFIER) {
       throw new Error("Expected an identifier");
     }
-    let identifierToken = this.getToken();
+    let identifier = this.parseIdentifier ();
     var args = [];
     while (this.peekToken().token != TOKENS.CLOSE_PAREN) {
       args.push(this.parseNextToken());
@@ -167,7 +174,7 @@ export default class ExampleParser {
     return new Expression(
       token.from,
       closeParenToken.to,
-      new Literal(identifierToken.from, identifierToken.to, identifierToken.text, 'symbol'),
+      identifier,
       args
     );
   }

--- a/src/languages/example/components/Literal.jsx
+++ b/src/languages/example/components/Literal.jsx
@@ -10,9 +10,9 @@ export default class Literal extends Component {
   }
 
   render() {
-    const {node} = this.props;
+    const {node, helpers, lockedTypes} = this.props;
     return (
-      <Node node={node}>
+      <Node node={node} helpers={helpers} lockedTypes={lockedTypes}>
         <span className="data-type">
           ({node.dataType})
         </span>

--- a/src/languages/example/components/Literal.jsx
+++ b/src/languages/example/components/Literal.jsx
@@ -7,6 +7,10 @@ import {Literal as LiteralASTNode} from '../../../ast';
 export default class Literal extends Component {
   static propTypes = {
     node: PropTypes.instanceOf(LiteralASTNode),
+    lockedTypes: PropTypes.instanceOf(Array).isRequired,
+    helpers: PropTypes.shape({
+      renderNodeForReact: PropTypes.func.isRequired,
+    }).isRequired,
   }
 
   render() {


### PR DESCRIPTION
Partly addresses #112 

**NOT DONE** quarantine nodes still create a toplevel React node that's rendered using `ReactDOM.render()` into some poor victim DOM node.

:large_blue_circle:  Now you're thinking with Portals! :red_circle: 

So the basic idea is to create a DOM tree and a React component tree like this.

DOM Tree
```
   <textarea><!-- the text area that CodeMirror took over --></textarea>
   <CodeMirror wrapper element>...</code mirror>
   <span class="code-mirror-react-root-container"/>
```
And into the code mirror React root container we render this React tree:
```
   <CodeMirrorContainer>
     <React.Portal target="code mirror root marker 1">
       <Node node="root 1" />
     </React.Portal>
     <React.Portal target="code mirror root marker 2">
       <Node node="root 2" />
     </React.Portal>
   </CodeMirrorContainer>
```

The invariant is that for every root AST node in the AST, there's a marker in CodeMirror that replaced the text range corresponding to that AST subtree with a `<span/>`.  The root `<CodeMirrorContainer/>` (sorry about the name) component then uses portals to render the AST root subtrees into the markers.  Easy peasy.

When there's a change to display, there's not a lot to do actually: all we need to do is update the code mirror markers so they have the right `marker.node` and then tell `<CodeMirrorContainer/>` that there was a state change.  And then let it run the render cycle.

(There's a slightly annoying bit with focusing where we have to force an update so that we can add a callback which will take care to focus on the correct block after the update - we should do this in a proper react-ful way by passing down a focused prop.)

### Quarantine nodes ###

Still use `RenderDOM.render()` on their own. :cry: 

I have an idea for how to handle them, but I didn't get to it yet.  Basically `<CodeMirrorContainer/>` should create a react Context in response to `this.state.quarantine` being set to a quarantine node.  Then every `<Node>` in the react tree will read from the context and compare the node id of the original node that the quarantine is hiding to its own.  If they match, don't draw the underlying block, draw the quarantine instead.

### TODO
- [ ] quarantine
- [ ] remove gratuitous `console.log`
- [ ] focus on the current block in a react-ful way
- [ ] check that tests are working
- [ ] `renderer.js` should probably go away - except the animation logic, the rest belongs in `CodeMirrorContainer`.
