### PR TITLE
Move duplicate code to ToggleEditor

### DIFF
--- a/src/CodeMirrorBlocks.js
+++ b/src/CodeMirrorBlocks.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ToggleEditor from './ui/ToggleEditor';
 import wescheme from '../src/languages/wescheme';
+import merge from './merge';
 
 // Consumes a DOM node to host the editor, a language object and the code
 // to render. Produces an object-representation of CMB, allowing for
@@ -19,7 +20,20 @@ export default class CodeMirrorBlocks {
       />,
       container
     );
+    merge(api, this.buildAPI());
     return api;
+  }
+
+  buildAPI = () => {
+    return {
+      'fromTextArea': this.fromTextArea,
+    }
+  }
+
+  fromTextArea = myTextArea => {
+    myTextArea.parentNode.replaceChild(<ToggleEditor
+      initialCode={myTextArea.value}
+    />, myTextArea);
   }
 }
 

--- a/src/CodeMirrorBlocks.js
+++ b/src/CodeMirrorBlocks.js
@@ -27,7 +27,7 @@ export default class CodeMirrorBlocks {
   buildAPI = () => {
     return {
       'fromTextArea': this.fromTextArea,
-    }
+    };
   }
 
   fromTextArea = myTextArea => {

--- a/src/ui/BlockEditor.js
+++ b/src/ui/BlockEditor.js
@@ -126,6 +126,7 @@ class BlockEditor extends Component {
       setCursor: PropTypes.func.isRequired,
     }),
     onBeforeChange: PropTypes.func,
+    onMount:PropTypes.func.isRequired,
     hasQuarantine: PropTypes.bool.isRequired,
     api: PropTypes.object,
 
@@ -340,6 +341,8 @@ class BlockEditor extends Component {
         this.markText(node.from, node.to, m.options);
       });
     }, 0));
+
+    this.props.onMount(ed);
 
     // export methods to the object interface
     merge(this.props.api, this.buildAPI(ed));

--- a/src/ui/BlockEditor.js
+++ b/src/ui/BlockEditor.js
@@ -349,38 +349,12 @@ class BlockEditor extends Component {
     let withState = (func) => this.props.dispatch((_, getState) => func(getState()));
     return {
       // cm methods
-      'markText':   (from, to, opts) => this.markText(from, to, opts),
       'findMarks':  (from, to) => this.findMarks(from, to),
       'findMarksAt':(pos) => this.findMarksAt(pos),
       'getAllMarks':() => this.getAllMarks(),
-      'getValue': (sep) => ed.getValue(sep),
-      'setValue': (value) => ed.setValue(value),
-      'getScrollerElement': () => ed.getScrollerElement(),
-      'getWrapperElement': () => ed.getWrapperElement(),
-      'getGutterElement': () => ed.getGutterElement(),
-      'getInputField': () => ed.getInputField(),
-      'getCursor': (start) => ed.getCursor(start),
-      'replaceRange': (str, from, to, origin) => ed.replaceRange(str, from, to, origin),
-      'setCursor': (pos) => this.props.setCursor(ed, pos),
+      'markText':   (from, to, opts) => this.markText(from, to, opts),
       'runMode': (_src, _lang, _container) => () => {}, // no-op since not an editing command
-      'refresh': () => ed.refresh(),
-      'defineOption': (name, _default, updateFunc) => ed.defineOption(name, _default, updateFunc),
-      'Pos': (line, ch, sticky) => ed.Pos(line, ch, sticky),
-      'Doc': (text, mode, firstLineNumber, lineSeparator) => ed.Doc(text, mode, firstLineNumber, lineSeparator),
-      'swapDoc': (doc) => ed.swapDoc(doc),
-      'getDoc': () => ed.getDoc(),
-      'charCoords': (pos, mode) => ed.charCoords(pos, mode),
-      'getScrollInfo': () => ed.getScrollInfo(),
-      'scrollIntoView': (what, margin) => ed.scrollIntoView(what, margin),
-      'addLineClass': (line, where, _class) => ed.addLineClass(line, where, _class),
-      'on': (type, func) => ed.on(type, func), // another on(obj, type, func) version...
-      'off': (type, func) => ed.off(type, func),
-      'removeLineClass': (line, where, _class) => ed.removeLineClass(line, where, _class),
-      'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
-      'getOption': (option) => ed.getOption(option),
-      'clearHistory': () => ed.clearHistory(),
-      'getDoc': () => ed.getDoc(),
-      'posFromIndex': (index) => ed.posFromIndex(index),
+      'setCursor': (pos) => this.props.setCursor(ed, pos),
       // block methods
       'getAst':
         () => withState((state) => state.ast),

--- a/src/ui/BlockEditor.js
+++ b/src/ui/BlockEditor.js
@@ -375,6 +375,7 @@ class BlockEditor extends Component {
       'on': (type, func) => ed.on(type, func), // another on(obj, type, func) version...
       'off': (type, func) => ed.off(type, func),
       'removeLineClass': (line, where, _class) => ed.removeLineClass(line, where, _class),
+      'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
       // block methods
       'getAst':
         () => withState((state) => state.ast),

--- a/src/ui/TextEditor.js
+++ b/src/ui/TextEditor.js
@@ -42,37 +42,12 @@ class TextEditor extends Component {
 
   buildAPI(ed) {
     return {
-      'markText': (from, to, opts) => ed.markText(from, to, opts),
-      'getAllMarks': () => ed.getAllMarks(),
       'findMarks': (from, to) => ed.findMarks(from, to),
       'findMarksAt': (pos) => ed.findMarksAt(pos),
-      'getValue': (sep) => ed.getValue(sep),
-      'setValue': (value) => ed.setValue(value),
-      'getScrollerElement': () => ed.getScrollerElement(),
-      'getGutterElement': () => ed.getGutterElement(),
-      'getCursor': (start) => ed.getCursor(start),
-      'setCursor': (pos) => ed.setCursor(pos),
+      'getAllMarks': () => ed.getAllMarks(),
+      'markText': (from, to, opts) => ed.markText(from, to, opts),
       'runMode': (src, lang, container) => ed.runMode(src, lang, container),
-      'refresh': () => ed.refresh(),
-      'defineOption': (name, _default, updateFunc) => ed.defineOption(name, _default, updateFunc),
-      'Pos': (line, ch, sticky) => ed.Pos(line, ch, sticky),
-      'Doc': (text, mode, firstLineNumber, lineSeparator) => ed.Doc(text, mode, firstLineNumber, lineSeparator),
-      'swapDoc': (doc) => ed.swapDoc(doc),
-      'getDoc': () => ed.getDoc(),
-      'charCoords': (pos, mode) => ed.charCoords(pos, mode),
-      'getScrollInfo': () => ed.getScrollInfo(),
-      'getWrapperElement': () => ed.getWrapperElement(),
-      'scrollIntoView': (what, margin) => ed.scrollIntoView(what, margin),
-      'addLineClass': (line, where, _class) => ed.addLineClass(line, where, _class),
-      'on': (type, func) => ed.on(type, func), // another on(obj, type, func) version...
-      'off': (type, func) => ed.off(type, func),
-      'removeLineClass': (line, where, _class) => ed.removeLineClass(line, where, _class),
-      'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
-      'getOption': (option) => ed.getOption(option), 
-      'clearHistory': () => ed.clearHistory(),
-      'getDoc': () => ed.getDoc(),
-      'posFromIndex': (index) => ed.posFromIndex(index),
-      'replaceRange': (str, from, to, origin) => ed.replaceRange(str, from, to, origin),
+      'setCursor': (pos) => ed.setCursor(pos),
     };
   }
 

--- a/src/ui/TextEditor.js
+++ b/src/ui/TextEditor.js
@@ -12,6 +12,7 @@ class TextEditor extends Component {
     parser: PropTypes.object.isRequired,
     initialCode: PropTypes.string.isRequired,
     onBeforeChange: PropTypes.func,
+    onMount:PropTypes.func.isRequired,
     setAnnouncer: PropTypes.func.isRequired,
     api: PropTypes.object,
   }
@@ -35,6 +36,8 @@ class TextEditor extends Component {
     setTimeout( () => {
       SHARED.recordedMarks.forEach(m => SHARED.cm.markText(m.from, m.to, m.options));
     }, 250);
+
+    this.props.onMount(ed);
 
     // export methods to the object interface
     merge(this.props.api, this.buildAPI(ed));

--- a/src/ui/TextEditor.js
+++ b/src/ui/TextEditor.js
@@ -66,6 +66,7 @@ class TextEditor extends Component {
       'on': (type, func) => ed.on(type, func), // another on(obj, type, func) version...
       'off': (type, func) => ed.off(type, func),
       'removeLineClass': (line, where, _class) => ed.removeLineClass(line, where, _class),
+      'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
     };
   }
 

--- a/src/ui/ToggleEditor.js
+++ b/src/ui/ToggleEditor.js
@@ -90,7 +90,6 @@ export default class ToggleEditor extends React.Component {
       'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
       'getOption': (option) => ed.getOption(option),
       'clearHistory': () => ed.clearHistory(),
-      'getDoc': () => ed.getDoc(),
       'posFromIndex': (index) => ed.posFromIndex(index),
     };
   }

--- a/src/ui/ToggleEditor.js
+++ b/src/ui/ToggleEditor.js
@@ -60,8 +60,6 @@ export default class ToggleEditor extends React.Component {
     this.options = merge(defaultOptions, props.options);
     this.hasMounted = false;
     SHARED.recordedMarks = new Map();
-
-    merge(this.props.api, this.buildAPI());
   }
 
   buildAPI(ed) {
@@ -95,6 +93,10 @@ export default class ToggleEditor extends React.Component {
       'getDoc': () => ed.getDoc(),
       'posFromIndex': (index) => ed.posFromIndex(index),
     };
+  }
+
+  handleEditorMounted = (ed) => {
+    merge(this.props.api, this.buildAPI(ed));
   }
 
   componentDidMount() {
@@ -172,6 +174,7 @@ export default class ToggleEditor extends React.Component {
         cmOptions={this.cmOptions}
         parser={this.parser}
         initialCode={code}
+        onMount={this.handleEditorMounted}
         api={this.props.api} />
     );
   }
@@ -183,6 +186,7 @@ export default class ToggleEditor extends React.Component {
         cmOptions={this.cmOptions}
         parser={this.parser}
         value={code}
+        onMount={this.handleEditorMounted}
         api={this.props.api}
         appElement={this.props.appElement}
         language={this.language.id}

--- a/src/ui/ToggleEditor.js
+++ b/src/ui/ToggleEditor.js
@@ -64,10 +64,36 @@ export default class ToggleEditor extends React.Component {
     merge(this.props.api, this.buildAPI());
   }
 
-  buildAPI() {
+  buildAPI(ed) {
     return {
       'getBlockMode': () => this.state.blockMode,
-      'setBlockMode': this.handleToggle
+      'setBlockMode': this.handleToggle,
+      'getValue': (sep) => ed.getValue(sep),
+      'setValue': (value) => ed.setValue(value),
+      'getScrollerElement': () => ed.getScrollerElement(),
+      'getWrapperElement': () => ed.getWrapperElement(),
+      'getGutterElement': () => ed.getGutterElement(),
+      'getInputField': () => ed.getInputField(), // wasn't in text editor
+      'getCursor': (start) => ed.getCursor(start),
+      'replaceRange': (str, from, to, origin) => ed.replaceRange(str, from, to, origin),
+      'refresh': () => ed.refresh(),
+      'defineOption': (name, _default, updateFunc) => ed.defineOption(name, _default, updateFunc),
+      'Pos': (line, ch, sticky) => ed.Pos(line, ch, sticky),
+      'Doc': (text, mode, firstLineNumber, lineSeparator) => ed.Doc(text, mode, firstLineNumber, lineSeparator),
+      'swapDoc': (doc) => ed.swapDoc(doc),
+      'getDoc': () => ed.getDoc(),
+      'charCoords': (pos, mode) => ed.charCoords(pos, mode),
+      'getScrollInfo': () => ed.getScrollInfo(),
+      'scrollIntoView': (what, margin) => ed.scrollIntoView(what, margin),
+      'addLineClass': (line, where, _class) => ed.addLineClass(line, where, _class),
+      'on': (type, func) => ed.on(type, func), // another on(obj, type, func) version...
+      'off': (type, func) => ed.off(type, func),
+      'removeLineClass': (line, where, _class) => ed.removeLineClass(line, where, _class),
+      'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
+      'getOption': (option) => ed.getOption(option),
+      'clearHistory': () => ed.clearHistory(),
+      'getDoc': () => ed.getDoc(),
+      'posFromIndex': (index) => ed.posFromIndex(index),
     };
   }
 

--- a/src/ui/ToggleEditor.js
+++ b/src/ui/ToggleEditor.js
@@ -64,33 +64,35 @@ export default class ToggleEditor extends React.Component {
 
   buildAPI(ed) {
     return {
+      // CMB methods
       'getBlockMode': () => this.state.blockMode,
       'setBlockMode': this.handleToggle,
-      'getValue': (sep) => ed.getValue(sep),
-      'setValue': (value) => ed.setValue(value),
-      'getScrollerElement': () => ed.getScrollerElement(),
-      'getWrapperElement': () => ed.getWrapperElement(),
-      'getGutterElement': () => ed.getGutterElement(),
-      'getInputField': () => ed.getInputField(), // wasn't in text editor
-      'getCursor': (start) => ed.getCursor(start),
-      'replaceRange': (str, from, to, origin) => ed.replaceRange(str, from, to, origin),
-      'refresh': () => ed.refresh(),
-      'defineOption': (name, _default, updateFunc) => ed.defineOption(name, _default, updateFunc),
-      'Pos': (line, ch, sticky) => ed.Pos(line, ch, sticky),
-      'Doc': (text, mode, firstLineNumber, lineSeparator) => ed.Doc(text, mode, firstLineNumber, lineSeparator),
-      'swapDoc': (doc) => ed.swapDoc(doc),
-      'getDoc': () => ed.getDoc(),
-      'charCoords': (pos, mode) => ed.charCoords(pos, mode),
-      'getScrollInfo': () => ed.getScrollInfo(),
-      'scrollIntoView': (what, margin) => ed.scrollIntoView(what, margin),
+      // CM methods
       'addLineClass': (line, where, _class) => ed.addLineClass(line, where, _class),
-      'on': (type, func) => ed.on(type, func), // another on(obj, type, func) version...
-      'off': (type, func) => ed.off(type, func),
-      'removeLineClass': (line, where, _class) => ed.removeLineClass(line, where, _class),
-      'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
-      'getOption': (option) => ed.getOption(option),
+      'charCoords': (pos, mode) => ed.charCoords(pos, mode),
       'clearHistory': () => ed.clearHistory(),
+      'defineOption': (name, _default, updateFunc) => ed.defineOption(name, _default, updateFunc),
+      'Doc': (text, mode, firstLineNumber, lineSeparator) => ed.Doc(text, mode, firstLineNumber, lineSeparator),
+      'getCursor': (start) => ed.getCursor(start),
+      'getDoc': () => ed.getDoc(),
+      'getGutterElement': () => ed.getGutterElement(),
+      'getInputField': () => ed.getInputField(),
+      'getOption': (option) => ed.getOption(option),
+      'getScrollerElement': () => ed.getScrollerElement(),
+      'getScrollInfo': () => ed.getScrollInfo(),
+      'getValue': (sep) => ed.getValue(sep),
+      'getWrapperElement': () => ed.getWrapperElement(),
+      'normalizeKeyMap': (keymap) => ed.normalizeKeyMap(keymap),
+      'off': (type, func) => ed.off(type, func),
+      'on': (type, func) => ed.on(type, func), // another on(obj, type, func) version...
+      'Pos': (line, ch, sticky) => ed.Pos(line, ch, sticky),
       'posFromIndex': (index) => ed.posFromIndex(index),
+      'refresh': () => ed.refresh(),
+      'removeLineClass': (line, where, _class) => ed.removeLineClass(line, where, _class),
+      'replaceRange': (str, from, to, origin) => ed.replaceRange(str, from, to, origin),
+      'scrollIntoView': (what, margin) => ed.scrollIntoView(what, margin),
+      'setValue': (value) => ed.setValue(value),
+      'swapDoc': (doc) => ed.swapDoc(doc),
     };
   }
 


### PR DESCRIPTION
This has required adding some proptypes to both BlockEditor and TextEditor so that ToggleEditor has access to the mounted editor.