### PR TITLE
Droptarget idea

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -174,27 +174,18 @@ the small squares betweeen nodes that you can drag blocks onto, or edit to
 insert a new child. When defining your blocks, you should include ample drop
 targets to make them easy to edit. There are two ways to get these.
 
-Most of the time, you should use `Args`. The syntax is `<Args
-location={loc}>{elts}</Args>`, which will intersperse drop targets horizontally
-among `elts` (which should be an array of elements). The prop `loc` is a source
-location---it is used only if `elts` is an empty array, in which case `Args` will
-have a single drop target and needs to know the source location for it.
+Most of the time, you should use `Args`. The syntax is `<Args>{elts}</Args>`,
+which will intersperse drop targets horizontally among `elts` (which should be
+an array of elements).
 
 In our `VariableDefinition` example, `Args` was sufficient so we just used that.
 
 However, if you want to put drop targets in a more interesting arrangement than
-`Args` gives you, you have a second option: you can use `DropTargetContainer`.
-Wrap the entirety of your `render()` result with
-`<DropTargetContainer>...</DropTargetContainer>`. Inside, you can freely use
-drop targets anywhere you like. The syntax is
+`Args` gives you, you have a second option: you can use `DropTarget`s directly.
+Simply construct them with `<DropTarget/>` anywhere in your node. They will
+figure out their correct source location automatically.
 
-    <DropTarget index={i} location={loc}/>
-
-This constructs a drop target with source location `loc` (i.e., if you drop
-something on it, that's the source location it will end up at). The index `i`
-distinguishes this drop target from any others inside the `DropTargetContainer`.
-
-There's one more thing you should do if you use `DropTargetContainer`.
+There's one more thing you should do if you make your own drop targets, though.
 CodeMirror-Blocks comes with a shortcut that lets you insert text to the left or
 right of a child of a node. For example, if you select the `1` in `(+ 1 2)` and
 type `ctrl-]`, then it will go into insert mode at the drop target between `1`
@@ -204,11 +195,10 @@ Instead, for `ctrl-[` and `ctrl-]` to work, you must explicitly say what drop
 targets a node is adjacent to. This is done via `DropTargetSibling`. Its syntax
 is:
 
-    <DropTargetSibling node={n} left={i} right={j}/>
+    <DropTargetSibling node={n} left={bool} right={bool}/>
 
-This renders the node `n`, while linking it to the drop target of index `i` on
-the left, and the drop target of index `j` on the right. If you want to omit a
-link, just omit `left` and/or `right`.
+This renders the node `n`, links it to the drop target to its left if `left`
+is true, and links it to the drop target to its right if `right` is true.
 
 -----
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -221,6 +221,7 @@ export function addWhitespacePadding(ast, text, from, to) {
   // We may need to insert a newline to make sure that comments don't end up
   // getting associated with the wrong node, and we may need to insert a space
   // to ensure that different tokens don't end up getting glommed together.
+  console.log("@addWhitespacePadding", ast, text, from, to);
   let prevChar = SHARED.cm.getRange({line: from.line, ch: from.ch - 1}, from);
   let nextChar = SHARED.cm.getRange(to, {line: to.line, ch: to.ch + 1});
   if (ast.followsComment(from) && prevChar != "") {

--- a/src/actions.js
+++ b/src/actions.js
@@ -221,7 +221,6 @@ export function addWhitespacePadding(ast, text, from, to) {
   // We may need to insert a newline to make sure that comments don't end up
   // getting associated with the wrong node, and we may need to insert a space
   // to ensure that different tokens don't end up getting glommed together.
-  console.log("@addWhitespacePadding", ast, text, from, to);
   let prevChar = SHARED.cm.getRange({line: from.line, ch: from.ch - 1}, from);
   let nextChar = SHARED.cm.getRange(to, {line: to.line, ch: to.ch + 1});
   if (ast.followsComment(from) && prevChar != "") {

--- a/src/components/Args.jsx
+++ b/src/components/Args.jsx
@@ -10,12 +10,13 @@ import {span} from '../types';
 
 export default class Args extends Component {
   static propTypes = {
+    node: PropTypes.instanceOf(ASTNode).isRequired,
     children: PropTypes.arrayOf(PropTypes.instanceOf(ASTNode)).isRequired,
     location: span,
   }
 
   render() {
-    let {children} = this.props;
+    let {node, children} = this.props;
     const elems = [];
     elems.push(<DropTarget key={'drop-0'}
                            index={0}
@@ -26,6 +27,6 @@ export default class Args extends Component {
                              index={index+1}
                              location={child.to} />);
     });
-    return elems;
+    return (<DropTargetContainer node={node}>{elems}</DropTargetContainer>);
   }
 }

--- a/src/components/Args.jsx
+++ b/src/components/Args.jsx
@@ -18,15 +18,11 @@ export default class Args extends Component {
   render() {
     let {node, children} = this.props;
     const elems = [];
-    elems.push(<DropTarget key={'drop-0'}
-                           index={0}
-                           location={children.length ? children[0].from : this.props.location} />);
+    elems.push(<DropTarget key={'drop-0'} />);
     children.forEach((child, index) => {
-      elems.push(<DropTargetSibling node={child} left={index} right={index+1} key={'node'+index} />);
-      elems.push(<DropTarget key={'drop-'+(index+1)}
-                             index={index+1}
-                             location={child.to} />);
+      elems.push(<DropTargetSibling node={child} left={true} right={true} key={'node'+index} />);
+      elems.push(<DropTarget key={'drop-'+(index+1)} />);
     });
-    return (<DropTargetContainer node={node}>{elems}</DropTargetContainer>);
+    return elems;
   }
 }

--- a/src/components/Args.jsx
+++ b/src/components/Args.jsx
@@ -26,6 +26,6 @@ export default class Args extends Component {
                              index={index+1}
                              location={child.to} />);
     });
-    return (<DropTargetContainer>{elems}</DropTargetContainer>);
+    return elems;
   }
 }

--- a/src/components/Args.jsx
+++ b/src/components/Args.jsx
@@ -5,14 +5,10 @@ import {ASTNode} from '../ast';
 import {DropTarget, DropTargetContainer, DropTargetSibling} from './DropTarget';
 import {span} from '../types';
 
-// NOTE: `location` is required in case `children` is empty!
-//       Otherwise, it can be omitted.
-
 export default class Args extends Component {
   static propTypes = {
     node: PropTypes.instanceOf(ASTNode).isRequired,
     children: PropTypes.arrayOf(PropTypes.instanceOf(ASTNode)).isRequired,
-    location: span,
   }
 
   render() {

--- a/src/components/Args.jsx
+++ b/src/components/Args.jsx
@@ -7,12 +7,11 @@ import {span} from '../types';
 
 export default class Args extends Component {
   static propTypes = {
-    node: PropTypes.instanceOf(ASTNode).isRequired,
     children: PropTypes.arrayOf(PropTypes.instanceOf(ASTNode)).isRequired,
   }
 
   render() {
-    let {node, children} = this.props;
+    let {children} = this.props;
     const elems = [];
     elems.push(<DropTarget key={'drop-0'} />);
     children.forEach((child, index) => {

--- a/src/components/ContentEditable.js
+++ b/src/components/ContentEditable.js
@@ -30,6 +30,7 @@ export default class ContentEditable extends Component {
     onKeyDown: PropTypes.func,
     itDidMount: PropTypes.func,
     value: PropTypes.string,
+    id: PropTypes.string,
   }
 
   handleChange = e => {

--- a/src/components/DropTarget.jsx
+++ b/src/components/DropTarget.jsx
@@ -9,7 +9,6 @@ import classNames from 'classnames';
 import {isErrorFree} from '../store';
 import {dropNode} from '../actions';
 import BlockComponent from './BlockComponent';
-import {ASTNode} from '../ast';
 import {NodeContext} from './Node';
 import uuidv4 from 'uuid/v4';
 
@@ -17,12 +16,11 @@ import uuidv4 from 'uuid/v4';
 // Use this class to render non-drop-target children of this node. Pass
 // in the `node` to be rendered, the index of the drop target to the `left` (or
 // `null` if there is none), and likewise for the `right`.
-const mapStateToProps1 = ({ast}) => ({ast});
 const mapDispatchToProps1 = dispatch => ({
   dispatch,
   setEditable: (id, bool) => dispatch({type: 'SET_EDITABLE', id, bool}),
 });
-@connect(mapStateToProps1, mapDispatchToProps1)
+@connect(null, mapDispatchToProps1)
 export class DropTargetSibling extends Component {
   static contextType = NodeContext;
 
@@ -40,7 +38,6 @@ export class DropTargetSibling extends Component {
 
     let prevDropTargetId = null;
     let targetId = `block-node-${this.props.node.id}`;
-    let ast = this.props.ast;
     
     function findDT(parent) {
       if (!parent.children) {
@@ -139,6 +136,9 @@ class ActualDropTarget extends BlockComponent {
   static contextType = NodeContext;
   
   static propTypes = {
+    // fulfilled by @connect
+    isEditable: PropTypes.bool.isRequired,
+    setEditable: PropTypes.func.isRequired,
     // Every DropTarget has a globally unique `id` which can be used to look up
     // its corresponding DOM element.
     id: PropTypes.string.isRequired,

--- a/src/components/Node.jsx
+++ b/src/components/Node.jsx
@@ -16,6 +16,10 @@ import {store} from '../store';
 import {playSound, BEEP} from '../sound';
 
 
+export const NodeContext = React.createContext({
+  node: null,
+});
+
 // TODO(Oak): make sure that all use of node.<something> is valid
 // since it might be cached and outdated
 // EVEN BETTER: is it possible to just pass an id?
@@ -276,7 +280,6 @@ class Node extends BlockComponent {
       case 'insertRight':
         e.preventDefault();
         if (e.ctrlKey) { // strictly want ctrlKey
-          // TODO: this should go up to the top level block
           if (this.props.onSetRight) {
             this.props.onSetRight(true);
           } else {
@@ -288,7 +291,6 @@ class Node extends BlockComponent {
       // insert-left
       case 'insertLeft':
         e.preventDefault();
-        // TODO: this should go up to the top level block
         if (this.props.onSetLeft) {
           this.props.onSetLeft(true);
         } else {
@@ -472,7 +474,9 @@ class Node extends BlockComponent {
       if (this.props.normallyEditable) {
         result = connectDropTarget(result);
       }
-      return connectDragPreview(connectDragSource(result), {offsetX: 1, offsetY: 1});
+      result = connectDragPreview(connectDragSource(result), {offsetX: 1, offsetY: 1});
+      result = (<NodeContext.Provider value={{node: this.props.node}}>{result}</NodeContext.Provider>);
+      return result;
     }
   }
 }

--- a/src/components/Node.jsx
+++ b/src/components/Node.jsx
@@ -21,9 +21,9 @@ import {playSound, BEEP} from '../sound';
 // EVEN BETTER: is it possible to just pass an id?
 
 @DragNodeSource
-@DropNodeTarget(({node}) => {
-  node = store.getState().ast.getNodeById(node.id);
-  return node.srcRange();
+@DropNodeTarget(function(monitor) {
+  let node = store.getState().ast.getNodeById(this.props.node.id);
+  return this.props.dispatch(dropNode(monitor.getItem(), node.srcRange()));
 })
 class Node extends BlockComponent {
   static defaultProps = {
@@ -496,7 +496,6 @@ const mapDispatchToProps = dispatch => ({
   uncollapse: id => dispatch({type: 'UNCOLLAPSE', id}),
   setCursor: cur => dispatch({type: 'SET_CURSOR', cur}),
   handleDelete: (id, selectionEditor) => dispatch(deleteNodes(id, selectionEditor)),
-  onDrop: (src, dest) => dispatch(dropNode(src, dest)),
   handleCopy: (id, selectionEditor) => dispatch(copyNodes(id, selectionEditor)),
   handlePaste: (id, isBackward) => dispatch(pasteNodes(id, isBackward)),
   activate: (id, options) => dispatch(activate(id, options)),

--- a/src/components/NodeEditable.js
+++ b/src/components/NodeEditable.js
@@ -16,7 +16,7 @@ class NodeEditable extends Component {
 
   static propTypes = {
     // NOTE: the presence of this Node means ast is not null
-    node: PropTypes.instanceOf(ASTNode),
+    node: PropTypes.object,
     children: PropTypes.node,
     isInsertion: PropTypes.bool.isRequired,
   }
@@ -34,7 +34,6 @@ class NodeEditable extends Component {
   }
 
   saveEdit = e => {
-    console.log("@saveEdit");
     e.stopPropagation();
     const {node, setErrorId, onChange, onDisableEditable, dispatch} = this.props;
     dispatch((_, getState) => {
@@ -109,7 +108,6 @@ class NodeEditable extends Component {
    */
 
   handleBlur = e => {
-    console.log("@blur", e.nativeEvent);
     if (this.ignoreBlur) return;
     this.saveEdit(e);
   }

--- a/src/nodes.jsx
+++ b/src/nodes.jsx
@@ -248,17 +248,19 @@ export class FunctionDefinition extends ASTNode {
   }
 
   render(props) {
+    let params = this.params.reactElement();
+    let body = this.body.reactElement();
     return (
       <Node node={this} {...props}>
         <span className="blocks-operator">
           define (
             <DropTarget/>
             <DropTargetSibling node={this.name} left={true} />
-            {this.params}
+            {params}
           )
         </span>
         <span className="blocks-args">
-          {this.body}
+          {body}
         </span>
       </Node>
     );

--- a/src/nodes.jsx
+++ b/src/nodes.jsx
@@ -34,7 +34,7 @@ export class Unknown extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">{firstElt}</span>
         <span className="blocks-args">
-        <Args node={this}>{restElts}</Args>
+        <Args>{restElts}</Args>
         </span>
       </Node>
     );
@@ -73,10 +73,10 @@ export class FunctionApp extends ASTNode {
     return (
       <Node node={this} {...props}>
         <span className="blocks-operator">
-          <Args node={this}>{[this.func]}</Args>
+          <Args>{[this.func]}</Args>
         </span>
         <span className="blocks-args">
-          <Args node={this}>{this.args}</Args>
+          <Args>{this.args}</Args>
         </span>
     </Node>
     );
@@ -107,7 +107,7 @@ export class IdentifierList extends ASTNode {
     return (
       <Node node={this} {...props}>
         <span className="blocks-args">
-          <Args node={this}>{this.ids}</Args>
+          <Args>{this.ids}</Args>
         </span>
       </Node>
     );
@@ -141,7 +141,7 @@ export class StructDefinition extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">
           define-struct
-          <Args node={this}>{[this.name]}</Args>
+          <Args>{[this.name]}</Args>
         </span>
         {fields}
       </Node>
@@ -176,7 +176,7 @@ export class VariableDefinition extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">
           define
-          <Args node={this}>{[this.name]}</Args>
+          <Args>{[this.name]}</Args>
         </span>
         <span className="blocks-args">
           {body}
@@ -484,7 +484,7 @@ export class Sequence extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">{this.name}</span>
         <div className="blocks-sequence-exprs">
-          <Args node={this}>{this.exprs}</Args>
+          <Args>{this.exprs}</Args>
         </div>
       </Node>
     );

--- a/src/nodes.jsx
+++ b/src/nodes.jsx
@@ -34,7 +34,7 @@ export class Unknown extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">{firstElt}</span>
         <span className="blocks-args">
-        <Args node={this} location={firstElt.to}>{restElts}</Args>
+        <Args node={this}>{restElts}</Args>
         </span>
       </Node>
     );
@@ -76,7 +76,7 @@ export class FunctionApp extends ASTNode {
           <Args node={this}>{[this.func]}</Args>
         </span>
         <span className="blocks-args">
-          <Args node={this} location={this.func.to}>{this.args}</Args>
+          <Args node={this}>{this.args}</Args>
         </span>
     </Node>
     );
@@ -107,7 +107,7 @@ export class IdentifierList extends ASTNode {
     return (
       <Node node={this} {...props}>
         <span className="blocks-args">
-          <Args node={this} location={this.from}>{this.ids}</Args>
+          <Args node={this}>{this.ids}</Args>
         </span>
       </Node>
     );
@@ -482,7 +482,7 @@ export class Sequence extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">{this.name}</span>
         <div className="blocks-sequence-exprs">
-          <Args node={this} location={this.name.to}>{this.exprs}</Args>
+          <Args node={this}>{this.exprs}</Args>
         </div>
       </Node>
     );

--- a/src/nodes.jsx
+++ b/src/nodes.jsx
@@ -72,12 +72,14 @@ export class FunctionApp extends ASTNode {
   render(props) {
     return (
       <Node node={this} {...props}>
-        <span className="blocks-operator">
-          <Args>{[this.func]}</Args>
-        </span>
-        <span className="blocks-args">
-          <Args location={this.func.to}>{this.args}</Args>
-        </span>
+        <DropTargetContainer node={this}>
+          <span className="blocks-operator">
+            <Args>{[this.func]}</Args>
+          </span>
+          <span className="blocks-args">
+            <Args location={this.func.to}>{this.args}</Args>
+          </span>
+        </DropTargetContainer>
       </Node>
     );
   }
@@ -249,7 +251,7 @@ export class FunctionDefinition extends ASTNode {
 
   render(props) {
     return (
-      <DropTargetContainer>
+      <DropTargetContainer node={this}>
         <Node node={this} {...props}>
           <span className="blocks-operator">
             define (
@@ -286,7 +288,7 @@ export class CondClause extends ASTNode {
 
   render(props) {
     return (
-      <DropTargetContainer>
+      <DropTargetContainer node={this}>
         <Node node={this} {...props}>
           <div className="blocks-cond-row">
             <div className="blocks-cond-predicate">
@@ -362,7 +364,7 @@ export class IfExpression extends ASTNode {
 
   render(props) {
     return (
-      <DropTargetContainer>
+      <DropTargetContainer node={this}>
         <Node node={this} {...props}>
           <span className="blocks-operator">if</span>
           <div className="blocks-cond-table">

--- a/src/nodes.jsx
+++ b/src/nodes.jsx
@@ -4,7 +4,7 @@ import {ASTNode, descDepth, enumerateList, pluralize} from './ast';
 import hashObject from 'object-hash';
 import Node from './components/Node';
 import Args from './components/Args';
-import {DropTarget, DropTargetContainer, DropTargetSibling} from './components/DropTarget';
+import {DropTarget, DropTargetSibling} from './components/DropTarget';
 
 
 export class Unknown extends ASTNode {
@@ -72,15 +72,13 @@ export class FunctionApp extends ASTNode {
   render(props) {
     return (
       <Node node={this} {...props}>
-        <DropTargetContainer node={this}>
-          <span className="blocks-operator">
-            <Args node={this}>{[this.func]}</Args>
-          </span>
-          <span className="blocks-args">
-            <Args node={this} location={this.func.to}>{this.args}</Args>
-          </span>
-        </DropTargetContainer>
-      </Node>
+        <span className="blocks-operator">
+          <Args node={this}>{[this.func]}</Args>
+        </span>
+        <span className="blocks-args">
+          <Args node={this} location={this.func.to}>{this.args}</Args>
+        </span>
+    </Node>
     );
   }
 }
@@ -251,20 +249,18 @@ export class FunctionDefinition extends ASTNode {
 
   render(props) {
     return (
-      <DropTargetContainer node={this}>
-        <Node node={this} {...props}>
-          <span className="blocks-operator">
-            define (
-              <DropTarget index={0} location={this.name.from} />
-              <DropTargetSibling node={this.name} left={0} />
-              <DropTargetSibling node={this.params} />
-            )
-          </span>
-          <span className="blocks-args">
-            <DropTargetSibling node={this.body} />
-          </span>
-        </Node>
-      </DropTargetContainer>
+      <Node node={this} {...props}>
+        <span className="blocks-operator">
+          define (
+            <DropTarget/>
+            <DropTargetSibling node={this.name} left={true} />
+            {this.params}
+          )
+        </span>
+        <span className="blocks-args">
+          {this.body}
+        </span>
+      </Node>
     );
   }
 }
@@ -288,24 +284,22 @@ export class CondClause extends ASTNode {
 
   render(props) {
     return (
-      <DropTargetContainer node={this}>
-        <Node node={this} {...props}>
-          <div className="blocks-cond-row">
-            <div className="blocks-cond-predicate">
-              <DropTarget index={0} location={this.testExpr.from} />
-              <DropTargetSibling node={this.testExpr} left={0} right={1} />
-            </div>
-            <div className="blocks-cond-result">
-              {this.thenExprs.map((thenExpr, index) => (
-                <span key={index}>
-                  <DropTarget index={index+1} location={thenExpr.from} />
-                  <DropTargetSibling node={thenExpr} left={index+1} right={index+2} />
-                </span>))}
-            </div>
+      <Node node={this} {...props}>
+        <div className="blocks-cond-row">
+          <div className="blocks-cond-predicate">
+            <DropTarget/>
+            <DropTargetSibling node={this.testExpr} left={true} right={true} />
           </div>
-          <DropTarget index={this.thenExprs.length + 1} location={this.from} />
-        </Node>
-      </DropTargetContainer>
+          <div className="blocks-cond-result">
+            {this.thenExprs.map((thenExpr, index) => (
+              <span key={index}>
+                <DropTarget/>
+                <DropTargetSibling node={thenExpr} left={true} right={true} />
+              </span>))}
+          </div>
+        </div>
+        <DropTarget/>
+      </Node>
     );
   }
 }
@@ -364,35 +358,33 @@ export class IfExpression extends ASTNode {
 
   render(props) {
     return (
-      <DropTargetContainer node={this}>
-        <Node node={this} {...props}>
-          <span className="blocks-operator">if</span>
-          <div className="blocks-cond-table">
-            <div className="blocks-cond-row">
-              <div className="blocks-cond-predicate">
-                <DropTarget index={0} location={this.testExpr.from} />
-                <DropTargetSibling node={this.testExpr} left={0} right={1} />
-              </div>
-              <div className="blocks-cond-result">
-                <DropTarget index={1} location={this.thenExpr.from} />
-                <DropTargetSibling node={this.thenExpr} left={1} right={2} />
-              </div>
+      <Node node={this} {...props}>
+        <span className="blocks-operator">if</span>
+        <div className="blocks-cond-table">
+          <div className="blocks-cond-row">
+            <div className="blocks-cond-predicate">
+              <DropTarget/>
+              <DropTargetSibling node={this.testExpr} left={true} right={true} />
             </div>
-            <div className="blocks-cond-row">
-              <div className="blocks-cond-predicate blocks-cond-else">
-                else
-              </div>
-              <div className="blocks-cond-result">
-                <DropTarget index={2} location={this.elseExpr.from} />
-                <DropTargetSibling node={this.elseExpr} left={2} right={3} />
-              </div>
-              <div className="blocks-cond-result">
-                <DropTarget index={3} location={this.elseExpr.to} />
-              </div>
+            <div className="blocks-cond-result">
+              <DropTarget/>
+              <DropTargetSibling node={this.thenExpr} left={true} right={true} />
             </div>
           </div>
-        </Node>
-      </DropTargetContainer>
+          <div className="blocks-cond-row">
+            <div className="blocks-cond-predicate blocks-cond-else">
+              else
+            </div>
+            <div className="blocks-cond-result">
+              <DropTarget/>
+              <DropTargetSibling node={this.elseExpr} left={true} right={true} />
+            </div>
+            <div className="blocks-cond-result">
+              <DropTarget/>
+            </div>
+          </div>
+        </div>
+      </Node>
     );
   }
 }

--- a/src/nodes.jsx
+++ b/src/nodes.jsx
@@ -34,7 +34,7 @@ export class Unknown extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">{firstElt}</span>
         <span className="blocks-args">
-        <Args location={firstElt.to}>{restElts}</Args>
+        <Args node={this} location={firstElt.to}>{restElts}</Args>
         </span>
       </Node>
     );
@@ -74,10 +74,10 @@ export class FunctionApp extends ASTNode {
       <Node node={this} {...props}>
         <DropTargetContainer node={this}>
           <span className="blocks-operator">
-            <Args>{[this.func]}</Args>
+            <Args node={this}>{[this.func]}</Args>
           </span>
           <span className="blocks-args">
-            <Args location={this.func.to}>{this.args}</Args>
+            <Args node={this} location={this.func.to}>{this.args}</Args>
           </span>
         </DropTargetContainer>
       </Node>
@@ -109,7 +109,7 @@ export class IdentifierList extends ASTNode {
     return (
       <Node node={this} {...props}>
         <span className="blocks-args">
-          <Args location={this.from}>{this.ids}</Args>
+          <Args node={this} location={this.from}>{this.ids}</Args>
         </span>
       </Node>
     );
@@ -143,7 +143,7 @@ export class StructDefinition extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">
           define-struct
-          <Args>{[this.name]}</Args>
+          <Args node={this}>{[this.name]}</Args>
         </span>
         {fields}
       </Node>
@@ -178,7 +178,7 @@ export class VariableDefinition extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">
           define
-          <Args>{[this.name]}</Args>
+          <Args node={this}>{[this.name]}</Args>
         </span>
         <span className="blocks-args">
           {body}
@@ -490,7 +490,7 @@ export class Sequence extends ASTNode {
       <Node node={this} {...props}>
         <span className="blocks-operator">{this.name}</span>
         <div className="blocks-sequence-exprs">
-          <Args location={this.name.to}>{this.exprs}</Args>
+          <Args node={this} location={this.name.to}>{this.exprs}</Args>
         </div>
       </Node>
     );

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,5 +1,6 @@
 const initialState = {
   selections: [],
+  editable: {},
   ast: null,
   focusId: null,
   collapsedList: [],
@@ -21,6 +22,8 @@ export const reducer = (
       return {...state, ast: action.ast, collapsedList: state.collapsedList.filter(action.ast.getNodeById)};
     case 'SET_SELECTIONS':
       return {...state, selections: action.selections};
+    case 'SET_EDITABLE':
+      return {...state, editable: {...state.editable, [action.id]: action.bool}};
     case 'SET_ERROR_ID':
       return {...state, errorId: action.errorId};
     case 'COLLAPSE':

--- a/src/ui/BlockEditor.js
+++ b/src/ui/BlockEditor.js
@@ -78,7 +78,7 @@ class ToplevelBlockEditableCore extends Component {
   render() {
     const {onDisableEditable, onChange, quarantine} = this.props;
     const [start, end, value] = quarantine;
-    const node = {id: 'editing', from: start, to: end};
+    const nodeProps = {id: 'editing', from: start, to: end};
     const props = {
       tabIndex          : '-1',
       role              : 'text box',
@@ -87,7 +87,7 @@ class ToplevelBlockEditableCore extends Component {
       'aria-level'      : '1',
     };
     return ReactDOM.createPortal(
-      <NodeEditable node={node}
+      <NodeEditable node={nodeProps}
                     value={value}
                     onChange={onChange}
                     contentEditableProps={props}

--- a/src/ui/DragAndDropEditor.js
+++ b/src/ui/DragAndDropEditor.js
@@ -3,14 +3,29 @@ import React  from 'react';
 import {DropNodeTarget} from '../dnd';
 import {dropNode} from '../actions';
 import {connect} from 'react-redux';
-
-const mapDispatchToProps = dispatch => ({
-  onDrop: (src, dest) => dispatch(dropNode(src, {...dest, isDropTarget: true})),
-});
+import SHARED from '../shared';
+import {playSound, BEEP} from '../sound';
 
 export default
-@connect(null, mapDispatchToProps)
-@DropNodeTarget(({location}) => ({from: location, to: location}))
+
+@connect(null, dispatch => ({dispatch}))
+
+@DropNodeTarget(function(monitor) {
+  let roots = SHARED.cm.getAllMarks().filter(m => m.BLOCK_NODE_ID);
+  const {x: left, y: top} = monitor.getClientOffset();
+  let validTopLevelDrop = !roots.some(root => {
+    let r = root.replacedWith.firstChild.getBoundingClientRect();
+    return (r.left<left) && (left<r.right) && (r.top<top) && (top<r.bottom);
+  });
+  if (validTopLevelDrop) {
+    let loc = SHARED.cm.coordsChar({left, top});
+    let dest = {from: loc, to: loc, isDropTarget: true}
+    return this.props.dispatch(dropNode(monitor.getItem(), dest));
+  } else { // beep and make it a no-op
+    playSound(BEEP);
+  }
+})
+
 class WrappedCodeMirror extends React.Component {
 
   handleDragOver = (ed, e) => {
@@ -22,7 +37,6 @@ class WrappedCodeMirror extends React.Component {
   handleDrop = (ed, e) => {
     // :( this never fire because of the other onDrop, although this onDrop
     // has the access to the information whether we drop at the right place :(
-    console.log(e);
   }
 
   render() {

--- a/src/ui/DragAndDropEditor.js
+++ b/src/ui/DragAndDropEditor.js
@@ -19,7 +19,7 @@ export default
   });
   if (validTopLevelDrop) {
     let loc = SHARED.cm.coordsChar({left, top});
-    let dest = {from: loc, to: loc, isDropTarget: true}
+    let dest = {from: loc, to: loc, isDropTarget: true};
     return this.props.dispatch(dropNode(monitor.getItem(), dest));
   } else { // beep and make it a no-op
     playSound(BEEP);


### PR DESCRIPTION
Many changes, that cumulatively result in fixing the issues introduced by the wip-optimization PR:

- Greatly simplify the drop target API. Drop targets no longer need `index` or `location`, Args no longer need `location`, and DropTargetContainers are no longer necessary at all.
- Drop target editing state is now stored in the Redux store, under `editable`.
- Nodes make themselves available to all of their descendants via a context called `NodeContext` with value `{node: _}`.
- DropTargets and DropTargetSiblings find themselves by walking the DOM.
- For annoying reasons, DropTargets need to have their `id` given to them as a prop, so there's now a wrapper Component around DropTargets that exists solely for the purpose of generating a uuidv4 and handing it to the DropTarget.
- The `DropNodeTarget` functionality is now specified at its three use sites, instead of being mixed at different places.