### PR TITLE
Automate TSC and formatting resulting JS files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# file to simplify running tsc and js-beautify
+DIR=src/languages/pyret
+FLAGS=--target es6 --jsx react
+
+all:	${DIR}/PyretParser.js ${DIR}/ast.js
+
+${DIR}/PyretParser.js:	${DIR}/PyretParser.ts
+	tsc ${FLAGS} $<
+
+${DIR}/ast.js:	${DIR}/ast.tsx
+	tsc ${FLAGS} $<

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file to simplify running tsc and js-beautify
 DIR=src/languages/pyret
 TSC_FLAGS=--target es6 --jsx react
-JS_B_FLAGS=--indent-size 2 --replace
+JS_B_FLAGS=--indent-size 2 --replace --brace-style preserve-inline
 
 all:	${DIR}/PyretParser.js ${DIR}/ast.js
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 # file to simplify running tsc and js-beautify
 DIR=src/languages/pyret
-FLAGS=--target es6 --jsx react
+TSC_FLAGS=--target es6 --jsx react
+JS_B_FLAGS=--indent-size 2 --replace
 
 all:	${DIR}/PyretParser.js ${DIR}/ast.js
 
 ${DIR}/PyretParser.js:	${DIR}/PyretParser.ts
-	tsc ${FLAGS} $<
+	# -tsc $< ${TSC_FLAGS}
+	js-beautify ${JS_B_FLAGS} $@
 
 ${DIR}/ast.js:	${DIR}/ast.tsx
-	tsc ${FLAGS} $<
+	# -tsc $< ${TSC_FLAGS}
+	js-beautify ${JS_B_FLAGS} $@

--- a/package.json
+++ b/package.json
@@ -110,6 +110,8 @@
     "build": "webpack --mode production",
     "build-debug": "webpack --mode development",
     "build-watch": "webpack --watch --mode development",
+    "watch-tsc": "tsc --watch",
+    "format-tsc-output": "make -B",
     "lint": "eslint src spec --ext .js || true",
     "site": "jekyll serve --baseurl \"\""
   },

--- a/src/languages/pyret/PyretParser.js
+++ b/src/languages/pyret/PyretParser.js
@@ -1,19 +1,9 @@
 import * as TOK from "./pyret-lang/pyret-tokenizer.js";
 import * as P from "./pyret-lang/pyret-parser.js";
 import * as TR from "./pyret-lang/translate-parse-tree.js";
-import {
-  AST
-} from '../../ast';
-import {
-  Literal,
-} from '../../nodes';
-import {
-  Binop,
-  ABlank,
-  Bind,
-  Func,
-  Sekwence as Sequence
-} from "./ast.js";
+import { AST } from '../../ast';
+import { Literal, } from '../../nodes';
+import { Binop, ABlank, Bind, Func, Sekwence as Sequence } from "./ast.js";
 class Range {
   constructor(from, to) {
     this.from = from;

--- a/src/languages/pyret/PyretParser.js
+++ b/src/languages/pyret/PyretParser.js
@@ -1,21 +1,33 @@
 import * as TOK from "./pyret-lang/pyret-tokenizer.js";
 import * as P from "./pyret-lang/pyret-parser.js";
 import * as TR from "./pyret-lang/translate-parse-tree.js";
-import { AST } from '../../ast';
-import { Literal, } from '../../nodes';
-import { Binop, ABlank, Bind, Func, Sekwence as Sequence } from "./ast.js";
+import {
+  AST
+} from '../../ast';
+import {
+  Literal,
+} from '../../nodes';
+import {
+  Binop,
+  ABlank,
+  Bind,
+  Func,
+  Sekwence as Sequence
+} from "./ast.js";
 class Range {
   constructor(from, to) {
     this.from = from;
     this.to = to;
   }
 }
+
 function startOf(srcloc) {
   return {
     "line": srcloc.startRow - 1,
     "ch": srcloc.startCol
   };
 }
+
 function endOf(srcloc) {
   return {
     "line": srcloc.endRow - 1,
@@ -43,94 +55,97 @@ const opLookup = {
 };
 // TODO: all of these are preliminary for testing
 const nodeTypes = {
-  "s-program": function (_pos, _prov, _provTy, _impt, body) {
+  "s-program": function(_pos, _prov, _provTy, _impt, body) {
     let rootNodes = body.exprs;
     return new AST(rootNodes);
   },
-  "s-name": function (pos, str) {
+  "s-name": function(pos, str) {
     return new Literal(pos.from, pos.to, str, 'symbol');
   },
-  "s-id": function (pos, str) {
+  "s-id": function(pos, str) {
     return new Literal(pos.from, pos.to, str, 'symbol');
   },
-  "s-num": function (pos, x) {
+  "s-num": function(pos, x) {
     return new Literal(pos.from, pos.to, x, 'number');
   },
-  "s-block": function (pos, stmts) {
+  "s-block": function(pos, stmts) {
     return new Sequence(pos.from, pos.to, stmts, 'block');
   },
-  "s-op": function (pos, _opPos, op, left, right) {
+  "s-op": function(pos, _opPos, op, left, right) {
     return new Binop(pos.from, pos.to, op.substr(2), left, right);
   },
-  "s-bind": function (pos, _shadows, id, ann) {
+  "s-bind": function(pos, _shadows, id, ann) {
     // TODO: ignoring shadowing for now.
     return new Bind(pos.from, pos.to, id, ann);
   },
-  "s-fun": function (pos, name, _params, args, ann, doc, body, _checkLoc, _check, _blodky) {
+  "s-fun": function(pos, name, _params, args, ann, doc, body, _checkLoc, _check, _blodky) {
     // TODO: ignoring params, check, blocky
     return new Func(pos.from, pos.to, name, args, ann, doc, body);
   },
   // Annotations
-  "a-blank": function () {
+  "a-blank": function() {
     return new ABlank(undefined, undefined);
   },
-  "a-name": function (pos, str) {
+  "a-name": function(pos, str) {
     return new Literal(pos.from, pos.to, str, 'symbol');
   }
 };
+
 function makeNode(nodeType) {
   const args = Array.prototype.slice.call(arguments, 1);
   const constructor = nodeTypes[nodeType];
   if (constructor === undefined) {
     console.log("Warning: node type", nodeType, "NYI");
     return;
-  }
-  else {
+  } else {
     return constructor.apply(this, args);
   }
 }
+
 function makeSrcloc(_fileName, srcloc) {
   return new Range(startOf(srcloc), endOf(srcloc));
 }
+
 function combineSrcloc(_fileName, startPos, endPos) {
   return new Range(startOf(startPos), endOf(endPos));
 }
+
 function translateParseTree(parseTree, fileName) {
   function NYI(msg) {
-    return function () {
+    return function() {
       console.log(msg, "not yet implemented");
     };
   }
   const constructors = {
     "makeNode": makeNode,
     "opLookup": opLookup,
-    "makeLink": function (a, b) {
+    "makeLink": function(a, b) {
       b.push(a); // Probably safe?
       return b;
     },
-    "makeEmpty": function () {
+    "makeEmpty": function() {
       return new Array();
     },
-    "makeString": function (str) {
+    "makeString": function(str) {
       return str;
     },
-    "makeNumberFromString": function (str) {
+    "makeNumberFromString": function(str) {
       // TODO: error handling
       return parseFloat(str);
     },
-    "makeBoolean": function (bool) {
+    "makeBoolean": function(bool) {
       return bool;
     },
-    "makeNone": function () {
+    "makeNone": function() {
       return null;
     },
-    "makeSome": function (value) {
+    "makeSome": function(value) {
       return value;
     },
     "getRecordFields": NYI("getRecordFields"),
     "makeSrcloc": makeSrcloc,
     "combineSrcloc": combineSrcloc,
-    "detectAndComplainAboutOperatorWhitespace": function (_kids, _fileName) {
+    "detectAndComplainAboutOperatorWhitespace": function(_kids, _fileName) {
       return;
     }
   };
@@ -158,16 +173,14 @@ export class PyretParser {
         // Translate parse tree to AST
         const ast = translateParseTree(parseTree, "<editor>.arr");
         return ast;
-      }
-      else {
+      } else {
         throw "Multiple parses";
       }
-    }
-    else {
+    } else {
       console.log("Invalid parse");
       // really, curTok does exist, but ts isn't smart enough to detect
-      console.log("Next token is " + tokenizer.curTok.toRepr(true)
-        + " at " + tokenizer.curTok.pos.toString(true));
+      console.log("Next token is " + tokenizer.curTok.toRepr(true) +
+        " at " + tokenizer.curTok.pos.toString(true));
     }
   }
   getExceptionMessage(error) {
@@ -175,6 +188,7 @@ export class PyretParser {
   }
 }
 module.exports = PyretParser;
+
 function testRun() {
   const data = `
   fun foo(x :: Number):

--- a/src/languages/pyret/PyretParser.ts
+++ b/src/languages/pyret/PyretParser.ts
@@ -16,12 +16,13 @@ import {Binop,
   Var,
   Assign,
   Let
-} from "./ast.js"
+} from "./ast.js";
 
 interface Position {
   line: number;
   ch: number;
 }
+
 class Range {
   from: Position;
   to: Position;

--- a/src/languages/pyret/ast.js
+++ b/src/languages/pyret/ast.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import Node from '../../components/Node';
 import * as P from '../../pretty';
-import {
-  ASTNode,
-  descDepth
-} from '../../ast';
+import { ASTNode, descDepth } from '../../ast';
 export class Binop extends ASTNode {
   constructor(from, to, op, left, right, options = {}) {
     super(from, to, 'binop', ['left', 'right'], options);
@@ -21,12 +18,8 @@ export class Binop extends ASTNode {
     return P.horzArray([this.left, P.txt(" "), this.op, P.txt(" "), this.right]);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-operator"
-      }, this.op),
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-operator" }, this.op),
       this.left.reactElement(),
       this.right.reactElement()));
   }
@@ -44,12 +37,8 @@ export class ABlank extends ASTNode {
     return P.standardSexpr('Any');
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-literal-symbol"
-      }, "BLANK")));
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-literal-symbol" }, "BLANK")));
   }
 }
 export class Bind extends ASTNode {
@@ -70,12 +59,8 @@ export class Bind extends ASTNode {
       return P.txt(this.id.value);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-literal-symbol"
-      }, this.id.value)));
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-literal-symbol" }, this.id.value)));
   }
 }
 export class Func extends ASTNode {
@@ -107,15 +92,9 @@ export class Func extends ASTNode {
   render(props) {
     let args = this.args_reversed.map(e => e.reactElement());
     let body = this.body.reactElement();
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-operator"
-      }, this.name),
-      React.createElement("span", {
-        className: "blocks-args"
-      }, args),
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-operator" }, this.name),
+      React.createElement("span", { className: "blocks-args" }, args),
       body));
   }
 }
@@ -134,12 +113,8 @@ export class Sekwence extends ASTNode {
     return P.vertArray(this.exprs.map(e => P.txt(e)));
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-operator"
-      }, this.name),
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-operator" }, this.name),
       this.exprs.map(e => e.reactElement())));
   }
 }
@@ -158,15 +133,9 @@ export class Var extends ASTNode {
     return P.txt(this.id + " = " + this.rhs);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-operator"
-      }, "VAR"),
-      React.createElement("span", {
-          className: "block-args"
-        },
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-operator" }, "VAR"),
+      React.createElement("span", { className: "block-args" },
         this.id.reactElement(),
         this.rhs.reactElement())));
   }
@@ -186,15 +155,9 @@ export class Assign extends ASTNode {
     return P.txt(this.id + ' := ' + this.rhs);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-operator"
-      }, ":="),
-      React.createElement("span", {
-          className: "block-args"
-        },
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-operator" }, ":="),
+      React.createElement("span", { className: "block-args" },
         this.id.reactElement(),
         this.rhs.reactElement())));
   }
@@ -214,15 +177,9 @@ export class Let extends ASTNode {
     return P.horzArray([this.id, P.txt('let'), this.rhs]);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({
-        node: this
-      }, props),
-      React.createElement("span", {
-        className: "blocks-operator"
-      }, "LET"),
-      React.createElement("span", {
-          className: "block-args"
-        },
+    return (React.createElement(Node, Object.assign({ node: this }, props),
+      React.createElement("span", { className: "blocks-operator" }, "LET"),
+      React.createElement("span", { className: "block-args" },
         this.id.reactElement(),
         this.rhs.reactElement())));
   }

--- a/src/languages/pyret/ast.js
+++ b/src/languages/pyret/ast.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import Node from '../../components/Node';
 import * as P from '../../pretty';
-import { ASTNode, descDepth } from '../../ast';
+import {
+  ASTNode,
+  descDepth
+} from '../../ast';
 export class Binop extends ASTNode {
   constructor(from, to, op, left, right, options = {}) {
     super(from, to, 'binop', ['left', 'right'], options);
@@ -18,8 +21,12 @@ export class Binop extends ASTNode {
     return P.horzArray([this.left, P.txt(" "), this.op, P.txt(" "), this.right]);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-operator" }, this.op),
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-operator"
+      }, this.op),
       this.left.reactElement(),
       this.right.reactElement()));
   }
@@ -37,8 +44,12 @@ export class ABlank extends ASTNode {
     return P.standardSexpr('Any');
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-literal-symbol" }, "BLANK")));
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-literal-symbol"
+      }, "BLANK")));
   }
 }
 export class Bind extends ASTNode {
@@ -59,8 +70,12 @@ export class Bind extends ASTNode {
       return P.txt(this.id.value);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-literal-symbol" }, this.id.value)));
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-literal-symbol"
+      }, this.id.value)));
   }
 }
 export class Func extends ASTNode {
@@ -81,7 +96,8 @@ export class Func extends ASTNode {
   }
   pretty() {
     let header = P.horzArray([P.txt("fun "), this.name,
-      P.txt("("), P.sepBy(", ", "", this.args_reversed.map(p => p.pretty())), P.txt("):")]);
+      P.txt("("), P.sepBy(", ", "", this.args_reversed.map(p => p.pretty())), P.txt("):")
+    ]);
     // either one line or multiple; helper for joining args together
     return P.ifFlat(P.horzArray([header, P.txt(" "), this.body, " end"]), P.vertArray([header,
       P.horz("  ", this.body),
@@ -91,9 +107,15 @@ export class Func extends ASTNode {
   render(props) {
     let args = this.args_reversed.map(e => e.reactElement());
     let body = this.body.reactElement();
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-operator" }, this.name),
-      React.createElement("span", { className: "blocks-args" }, args),
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-operator"
+      }, this.name),
+      React.createElement("span", {
+        className: "blocks-args"
+      }, args),
       body));
   }
 }
@@ -112,8 +134,12 @@ export class Sekwence extends ASTNode {
     return P.vertArray(this.exprs.map(e => P.txt(e)));
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-operator" }, this.name),
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-operator"
+      }, this.name),
       this.exprs.map(e => e.reactElement())));
   }
 }
@@ -132,9 +158,15 @@ export class Var extends ASTNode {
     return P.txt(this.id + " = " + this.rhs);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-operator" }, "VAR"),
-      React.createElement("span", { className: "block-args" },
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-operator"
+      }, "VAR"),
+      React.createElement("span", {
+          className: "block-args"
+        },
         this.id.reactElement(),
         this.rhs.reactElement())));
   }
@@ -154,9 +186,15 @@ export class Assign extends ASTNode {
     return P.txt(this.id + ' := ' + this.rhs);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-operator" }, ":="),
-      React.createElement("span", { className: "block-args" },
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-operator"
+      }, ":="),
+      React.createElement("span", {
+          className: "block-args"
+        },
         this.id.reactElement(),
         this.rhs.reactElement())));
   }
@@ -176,9 +214,15 @@ export class Let extends ASTNode {
     return P.horzArray([this.id, P.txt('let'), this.rhs]);
   }
   render(props) {
-    return (React.createElement(Node, Object.assign({ node: this }, props),
-      React.createElement("span", { className: "blocks-operator" }, "LET"),
-      React.createElement("span", { className: "block-args" },
+    return (React.createElement(Node, Object.assign({
+        node: this
+      }, props),
+      React.createElement("span", {
+        className: "blocks-operator"
+      }, "LET"),
+      React.createElement("span", {
+          className: "block-args"
+        },
         this.id.reactElement(),
         this.rhs.reactElement())));
   }


### PR DESCRIPTION
I added types to Pyret's parser and ast files for documentation purposes. This PR adds a command to watch these files and recompile on changes and a command to beautify the resulting JS files, which differ from the rest of the project in indentation.