### PR TITLE
fix incorrect codemirror import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A library for making functional languages editable using visual blocks inside of
 
 4. Hook it up:
 
-        import CodeMirror from 'CodeMirror'
+        import CodeMirror from 'codemirror'
         import CodeMirrorBlocks from 'codemirror-blocks'
         import MyParser from './MyParser.js' //See example/parser.js for an example
 

--- a/webpack/bundle.config.js
+++ b/webpack/bundle.config.js
@@ -17,7 +17,7 @@ var configs = [
     },
     plugins: [new webpack.ProvidePlugin({ codemirror: "codemirror" })],
     externals: {
-      'codemirror': 'CodeMirror',
+      'codemirror': 'codemirror',
     },
   })
 ];


### PR DESCRIPTION
Using `import .... from "CodeMirror"` should work on machines
with case-insensitive file systems (i.e., OSX), but will throw a
"module could not be found" error on machines with case-sensitive
file systems, where `codemirror` is the correct path.
