### PR TITLE
Fix 271

### DIFF
--- a/example/new-editor-example.js
+++ b/example/new-editor-example.js
@@ -3,10 +3,10 @@ import CodeMirrorBlocks from '../src/CodeMirrorBlocks';
 import './example-page.less';
 import bigExampleCode from './ast-test.rkt';
 import hugeExampleCode from './huge-code.rkt';
-const smallExampleCode = `(+ 1 2) ;comment\n(+ 3 4)`;
+const smallExampleCode = `(collapse me)\n(+ 1 2)`;
 
-//const exampleCode = smallExampleCode;
-const exampleCode = bigExampleCode;
+const exampleCode = smallExampleCode;
+//const exampleCode = bigExampleCode;
 //const exampleCode = hugeExampleCode;
 
 // grab the DOM Node to host the editor, and use it to instantiate

--- a/spec/index.js
+++ b/spec/index.js
@@ -2,5 +2,5 @@
 require('@babel/polyfill');
 
 // require all the files in the spec folder that end with -test.js
-var context = require.context('.', true, /.-test\.js$/);
+var context = require.context('.', true, /.-lab\.js$/);
 context.keys().forEach(context);

--- a/spec/index.js
+++ b/spec/index.js
@@ -2,5 +2,5 @@
 require('@babel/polyfill');
 
 // require all the files in the spec folder that end with -test.js
-var context = require.context('.', true, /.-lab\.js$/);
+var context = require.context('.', true, /.-test\.js$/);
 context.keys().forEach(context);

--- a/spec/reduced-test-lab.js
+++ b/spec/reduced-test-lab.js
@@ -23,8 +23,8 @@ describe("trying to create a simple regression test", function () {
     this.cmb.setValue('(collapse me)\n(+ 1 2)');
     await wait(DELAY);
     this.retrieve = function() {
-        this.firstRoot = this.cmb.getAst().rootNodes[0];
-        this.lastDropTarget = document.querySelectorAll('.blocks-drop-target')[4];
+      this.firstRoot = this.cmb.getAst().rootNodes[0];
+      this.lastDropTarget = document.querySelectorAll('.blocks-drop-target')[4];
     };
     this.retrieve();
   });

--- a/spec/reduced-test-lab.js
+++ b/spec/reduced-test-lab.js
@@ -20,14 +20,12 @@ describe("trying to create a simple regression test", function () {
   beforeEach(async function () {
     setup.call(this);
 
-    this.cmb.setValue('(print moo)\n(+ 1 2)');
+    this.cmb.setValue('(collapse me)\n(+ 1 2)');
+    await wait(DELAY);
     this.retrieve = function() {
         this.firstRoot = this.cmb.getAst().rootNodes[0];
-        this.secondRoot = this.cmb.getAst().rootNodes[1];
-        this.dropTargetEls = document.querySelectorAll('.blocks-drop-target');
-        this.lastDropTarget = this.dropTargetEls[4];
+        this.lastDropTarget = document.querySelectorAll('.blocks-drop-target')[4];
     };
-    await wait(DELAY);
     this.retrieve();
   });
 
@@ -45,7 +43,7 @@ describe("trying to create a simple regression test", function () {
     this.retrieve();
     this.newFirstRoot = this.cmb.getAst().rootNodes[0];
     this.newLastChild = this.newFirstRoot.args[2];
-    expect(this.cmb.getValue()).toBe('\n(+ 1 2 (print moo))');
+    expect(this.cmb.getValue()).toBe('\n(+ 1 2 (collapse me))');
     expect(this.newFirstRoot.element.getAttribute('aria-expanded')).toBe('true');
     expect(this.newLastChild.element.getAttribute('aria-expanded')).toBe('false');
   });

--- a/spec/reduced-test-lab.js
+++ b/spec/reduced-test-lab.js
@@ -31,7 +31,7 @@ describe("trying to create a simple regression test", function () {
 
   afterEach(function () { teardown(); });
 
-  it('drag a collapsed root to be the last child of the next root', async function () {
+  it('save collapsed state when dragging root to be the last child of the next root', async function () {
     mouseDown(this.firstRoot); // click the root
     keyDown("ArrowLeft", {}, this.firstRoot); // collapse it
     expect(this.firstRoot.element.getAttribute('aria-expanded')).toBe('false');

--- a/src/actions.js
+++ b/src/actions.js
@@ -108,7 +108,7 @@ export function drop(src, target, onSuccess, onError) {
   }
 
   let edits = [];
-  let droppedHash, draggedHash;
+  let droppedHash;
 
   // Assuming it did not come from the toolbar...
   // (1) Delete the text of the dragged node, (2) and save the id and hash

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -51,6 +51,7 @@ export const reducer = (
     break;
   case 'SET_AST':
     result = {...state, ast: action.ast, collapsedList: state.collapsedList.filter(action.ast.getNodeById)};
+    console.log('AST nodeIdMap is', result.ast.nodeIdMap);
     break;
   case 'SET_SELECTIONS':
     result = {...state, selections: action.selections};

--- a/src/utils.js
+++ b/src/utils.js
@@ -278,7 +278,9 @@ export function minimizeChange({from, to, text, removed, origin=undefined}) {
   return origin ? {from, to, text, removed, origin} : {from, to, text, removed};
 }
 
+// display the actual exception, and try to log it
 export function logResults(history, exception) {
+  console.log(exception, history);
   try {
     document.getElementById('history').value = JSON.stringify(history);
     document.getElementById('exception').value = exception;


### PR DESCRIPTION
Surgical fix for #271, which...

- checks to see if the dragged node was collapsed, and if so...
- remembers the `nodeId` and `hash` of the dragged node when one occurs
- looks at the post-edit AST and finds the corresponding `nodeId` based on the `hash`
- changes the `collapsedList` so that the old `nodeId` is uncollapsed and the new one is

**This is likely imperfect, since the patching algorithm may arbitrarily reshuffle all nodes that have the same hash.**

I have a sneaking suspicion that a more permanent fix may require a change to the patching algorithm. Ugh.