### PR TITLE
Focus-on-1st-root when tabbed

### DIFF
--- a/spec/activation-test.js
+++ b/spec/activation-test.js
@@ -224,7 +224,6 @@ describe('tree navigation', function () {
     keyDown("ArrowLeft", {}, this.firstRoot); // collapse that root
     mouseDown(this.thirdRoot.args[1].args[0]);
     await wait(DELAY);
-    expect(this.activeNode().id).toBe(this.thirdRoot.args[1].args[0].id);
     expect(this.activeNode()).toBe(this.thirdRoot.args[1].args[0]);
 
     keyDown("ArrowDown");
@@ -303,7 +302,7 @@ describe('tree navigation', function () {
     keyDown("<", { shiftKey: true }, this.thirdRoot.args[1].args[1]);
     await wait(DELAY);
     expect(this.thirdRoot.element.getAttribute("aria-expanded")).toBe("true");
-    expect(this.activeNode().id).toBe(this.thirdRoot.id);
+    expect(this.activeNode()).toBe(this.thirdRoot);
   });
 
   it('right-arrow should expand a block, or shift focus to 1st child', async function () {

--- a/spec/activation-test.js
+++ b/spec/activation-test.js
@@ -26,6 +26,7 @@ describe("when dealing with node activation,", function () {
     let ast = this.cmb.getAst();
     this.literal1 = ast.rootNodes[0];
     this.literal2 = ast.rootNodes[1];
+    await wait(DELAY);
   });
 
   afterEach(function () { teardown(); });
@@ -180,7 +181,7 @@ describe('cut/copy/paste', function () {
 });
 
 describe('tree navigation', function () {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup.call(this);
 
     this.cmb.setValue('(+ 1 2 3) 99 (* 7 (* 1 2))');
@@ -194,6 +195,7 @@ describe('tree navigation', function () {
     this.thirdArg   = ast.rootNodes[0].args[2];
     this.nestedExpr = ast.rootNodes[2].args[1];
     this.lastNode   = this.thirdRoot.args[1].args[1];
+    await wait(DELAY);
   });
 
   afterEach(function () { teardown(); });
@@ -222,6 +224,7 @@ describe('tree navigation', function () {
     keyDown("ArrowLeft", {}, this.firstRoot); // collapse that root
     mouseDown(this.thirdRoot.args[1].args[0]);
     await wait(DELAY);
+    expect(this.activeNode().id).toBe(this.thirdRoot.args[1].args[0].id);
     expect(this.activeNode()).toBe(this.thirdRoot.args[1].args[0]);
 
     keyDown("ArrowDown");
@@ -300,7 +303,7 @@ describe('tree navigation', function () {
     keyDown("<", { shiftKey: true }, this.thirdRoot.args[1].args[1]);
     await wait(DELAY);
     expect(this.thirdRoot.element.getAttribute("aria-expanded")).toBe("true");
-    expect(this.activeNode()).toBe(this.thirdRoot);
+    expect(this.activeNode().id).toBe(this.thirdRoot.id);
   });
 
   it('right-arrow should expand a block, or shift focus to 1st child', async function () {
@@ -351,7 +354,7 @@ describe('tree navigation', function () {
 });
 
 describe("when dealing with node selection, ", function () {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup.call(this);
 
     this.cmb.setValue('11\n54\n(+ 1 2)');
@@ -359,6 +362,7 @@ describe("when dealing with node selection, ", function () {
     this.literal1 = ast.rootNodes[0];
     this.literal2 = ast.rootNodes[1];
     this.expr = ast.rootNodes[2];
+    await wait(DELAY);
   });
 
   afterEach(function () { teardown(); });

--- a/spec/activation-test.js
+++ b/spec/activation-test.js
@@ -200,7 +200,7 @@ describe('tree navigation', function () {
 
   it('up-arrow should navigate to the previous visible node, but not beyond the tree', async function () {
     mouseDown(this.firstRoot);
-    keyDown("ArrowLeft", {}, this.firstRoot);
+    keyDown("ArrowLeft", {}, this.firstRoot); // collapse that root
     mouseDown(this.secondRoot);
     await wait(DELAY);
     expect(this.activeNode()).toBe(this.secondRoot);
@@ -219,7 +219,7 @@ describe('tree navigation', function () {
 
   it('down-arrow should navigate to the next sibling, but not beyond the tree', async function () {
     mouseDown(this.firstRoot);
-    keyDown("ArrowLeft", {}, this.firstRoot);
+    keyDown("ArrowLeft", {}, this.firstRoot); // collapse that root
     mouseDown(this.thirdRoot.args[1].args[0]);
     await wait(DELAY);
     expect(this.activeNode()).toBe(this.thirdRoot.args[1].args[0]);
@@ -237,14 +237,14 @@ describe('tree navigation', function () {
 
   it('left-arrow should collapse a block, if it can be', async function () {
     mouseDown(this.firstRoot);
-    keyDown("ArrowLeft", {}, this.firstRoot);
+    keyDown("ArrowLeft", {}, this.firstRoot); // collapse that root
     mouseDown(this.firstRoot);
-    keyDown("ArrowLeft", {}, this.firstRoot);
+    keyDown("ArrowLeft", {}, this.firstRoot); // collapse that root *again*
     await wait(DELAY);
     expect(this.firstRoot.element.getAttribute("aria-expanded")).toBe("false");
 
     mouseDown(this.secondRoot);
-    keyDown("ArrowLeft", {}, this.secondRoot);
+    keyDown("ArrowLeft", {}, this.secondRoot); // collapse that root
     await wait(DELAY);
     expect(this.secondRoot.element.getAttribute("aria-expanded")).toBe(null);
   });

--- a/spec/focus-test.js
+++ b/spec/focus-test.js
@@ -30,6 +30,11 @@ describe('The CodeMirrorBlocks Class', function() {
       this.literal3 = this.expression.args[2];
     });
 
+    it('tabbing to the editor for the first time should activate node 0', async function() {
+      this.cmb.focus();
+      expect(this.blocks.getFocusedNode().nid).toBe(0);
+    });
+
     it('deleting the last node should shift focus to the next-to-last', async function() {
       mouseDown(this.literal3);
       await wait(DELAY);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -209,18 +209,18 @@ export class AST {
    */
   getNodeAfterCur = cur => {
     function loop(nodes, parentFallback) {
-      console.log('ast:211, cur?=', !!cur);
+      //console.log('ast:211, cur?=', !!cur);
       let n = nodes.find(n => poscmp(n.to, cur) > 0); // find the 1st node that ends after cur
-      console.log('ast:213');
+      //console.log('ast:213');
       if(!n) {
-        console.log('ast:214');
+        //console.log('ast:214');
         return parentFallback; }               // return null if there's no node after the cursor
       if(poscmp(n.from, cur) >= 0) {
-        console.log('ast:218');
+        //console.log('ast:218');
         return n; }      // if the node *starts* after the cursor too, we're done
-      console.log('ast:220');
+      //console.log('ast:220');
       let children = [...n.children()];               // if *contains* cur, drill down into the children
-      console.log('ast:222');
+      //console.log('ast:222');
       return (children.length == 0)? n : loop(children, n);
     }
     return loop(this.rootNodes, null);
@@ -300,9 +300,8 @@ export class AST {
   followsComment(pos) {
     // TODO: efficiency
     for (const node of this.nodeIdMap.values()) {
-      if (node.options.comment
-          && node.options.comment.to.line == pos.line
-          && node.options.comment.to.ch <= pos.ch) {
+      if (node.options.comment?.to.line == pos.line
+          && node.options.comment?.to.ch <= pos.ch) {
         return true;
       } else if (node.options.comment
                  && node.to.line == pos.line
@@ -321,9 +320,8 @@ export class AST {
   precedesComment(pos) {
     // TODO: efficiency
     for (const node of this.nodeIdMap.values()) {
-      if (node.options.comment
-          && node.options.comment.from.line == pos.line
-          && pos.ch <= node.options.comment.from.ch) {
+      if (node.options.comment?.from.line == pos.line
+          && pos.ch <= node.options.comment?.from.ch) {
         return true;
       } else if (node.options.comment
                  && node.from.line == pos.line

--- a/src/components/DropTarget.jsx
+++ b/src/components/DropTarget.jsx
@@ -37,13 +37,13 @@ export function findAdjacentDropTargetId(child, onLeft) {
     if (!onLeft) { children.reverse(); }
 
     for (let sibling of children) {
-      if (sibling.id && sibling.id.startsWith("block-drop-target-")) {
+      if (sibling.id?.startsWith("block-drop-target-")) {
         // We've hit a drop-target. Remember its id, in case it's adjacent to the node.
         prevDropTargetId = sibling.id.substring(18); // skip "block-drop-target-"
       } else if (sibling.id == targetId) {
         // We've found this node! Return the id of the adjacent drop target.
         return prevDropTargetId;
-      } else if (sibling.id && sibling.id.startsWith("block-node-")) {
+      } else if (sibling.id?.startsWith("block-node-")) {
         // It's a different node. Skip it.
       } else if (sibling.children) {
         // We're... somewhere else. If it has children, traverse them to look for the node.
@@ -144,11 +144,11 @@ class ActualDropTarget extends BlockComponent {
         return null;
       }
       // We've hit an ASTNode. Remember its id, in case it's the node just before the drop target.
-      if (elem.id && elem.id.startsWith("block-node-")) {
+      if (elem.id?.startsWith("block-node-")) {
         prevNodeId = elem.id.substring(11); // skip "block-node-"
       }
       for (let sibling of elem.children) {
-        if (sibling.id && sibling.id.startsWith("block-node-")) {
+        if (sibling.id?.startsWith("block-node-")) {
           // We've hit an ASTNode. Remember its id, in case it's the node just before the drop target.
           prevNodeId = sibling.id.substring(11); // skip "block-node-"
           if (dropTargetWasFirst) {
@@ -164,7 +164,7 @@ class ActualDropTarget extends BlockComponent {
             // Edge case: nothing is before the drop target.
             dropTargetWasFirst = true;
           }
-        } else if (sibling.id && sibling.id.startsWith("block-drop-target")) {
+        } else if (sibling.id?.startsWith("block-drop-target")) {
           // It's a different drop target. Skip it.
         } else if (sibling.children) {
           // We're... somewhere else. If it has children, traverse them to look for the drop target.

--- a/src/components/Node.jsx
+++ b/src/components/Node.jsx
@@ -142,7 +142,7 @@ class Node extends BlockComponent {
   }
 
   isLocked() {
-    if (SHARED.options && SHARED.options.renderOptions) {
+    if (SHARED.options?.renderOptions) {
       const lockedList = SHARED.options.renderOptions.lockNodesOfType;
       return lockedList.includes(this.props.node.type);
     }
@@ -206,7 +206,7 @@ class Node extends BlockComponent {
         connectDragPreview
       } = this.props;
       classes.push({'blocks-over-target': isOver, 'blocks-node': true});
-      if(textMarker && textMarker.options.className) classes.push(textMarker.options.className);
+      if(textMarker?.options.className) classes.push(textMarker.options.className);
       let result = (
         <span
           {...props}

--- a/src/edits/commitChanges.js
+++ b/src/edits/commitChanges.js
@@ -45,8 +45,8 @@ export function commitChanges(
     // Patch the tree and set the state
     newAST = patch(oldAST, newAST);
     store.dispatch({type: 'SET_AST', ast: newAST});
-    // Set the focus.
-    let focusId = setFocus(changes, focusHint, newAST);
+    // Try to set the focus using hinting data. If that fails, use the first root
+    let focusId = setFocus(changes, focusHint, newAST) || newAST.getFirstRootNode()?.id;
     //console.log('XXX commitChanges:50 setFocus retd focusId=', focusId);
     if (!isUndoOrRedo) {
       // `DO` must be dispatched every time _any_ edit happens on CodeMirror:
@@ -54,7 +54,7 @@ export function commitChanges(
         //console.log('commitChanges:54 focusId=', focusId);
       let newFocus = null;
       if (focusId) {  newFocus = newAST.getNodeById(focusId); }
-      let newFocusNId = newFocus ? newFocus.nid : null;
+      let newFocusNId = newFocus?.nid;
       //console.log('XXX commitChanges:58 oldFocusNId=', oldFocusNId);
       //console.log('XXX commitChanges:59 newFocusNId=', newFocusNId);
       //console.log('XXX commitChanges:60 annt=', annt);

--- a/src/edits/patchAst.js
+++ b/src/edits/patchAst.js
@@ -38,7 +38,7 @@ export default function unify(oldTree, newTree) {
 
     let partiallySuccess = false;
     const newLeftover = [...newTree.children()].filter(newNode => {
-      if (index[newNode.hash] && index[newNode.hash].length > 0) {
+      if (index[newNode.hash]?.length > 0) {
         const oldNode = index[newNode.hash].pop();
         copyAllIds(oldNode, newNode);
         partiallySuccess = true;

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -208,7 +208,7 @@ export const commandMap = {
     const node = this.node;
     if (this.expandable && this.isCollapsed && !this.isLocked()) {
       this.uncollapse(node.id);
-    } else if (node.next && node.next.parent === node) {
+    } else if (node.next?.parent === node) {
       //console.log('XXX keymap:212, calling activateByNid');
       this.activateByNid(node.next.nid);
     } else {

--- a/src/ui/BlockEditor.js
+++ b/src/ui/BlockEditor.js
@@ -275,7 +275,7 @@ class BlockEditor extends Component {
     // activate a node; only when the editor is focused, the focused node will be
     // active
     if (ast.rootNodes.length > 0) {
-      this.props.dispatch({type: 'SET_FOCUS', focusId: String(ast.rootNodes[0].id)});
+      this.props.dispatch({type: 'SET_FOCUS', focusId: ast.rootNodes[0].id});
     }
     // a tree element should know how many roots it has
     wrapper.setAttribute('aria-setsize', ast.rootNodes.length);

--- a/src/ui/BlockEditor.js
+++ b/src/ui/BlockEditor.js
@@ -275,7 +275,7 @@ class BlockEditor extends Component {
     // activate a node; only when the editor is focused, the focused node will be
     // active
     if (ast.rootNodes.length > 0) {
-      this.props.dispatch({type: 'SET_FOCUS', focusId: ast.rootNodes[0].id});
+      this.props.dispatch({type: 'SET_FOCUS', focusId: String(ast.rootNodes[0].id)});
     }
     // a tree element should know how many roots it has
     wrapper.setAttribute('aria-setsize', ast.rootNodes.length);

--- a/src/ui/BlockEditor.js
+++ b/src/ui/BlockEditor.js
@@ -685,10 +685,7 @@ const mapDispatchToProps = dispatch => ({
     return dispatch({type: 'SET_FOCUS', focusId: null});
   },
   setQuarantine: (start, end, text) => dispatch({type: 'SET_QUARANTINE', start, end, text}),
-  activateByNid: function(nid, options) {
-    //console.log('XXX BlockEditor:689 calling activateByNid I', nid);
-    if (nid !== null) return dispatch(activateByNid(nid, options));
-  },
+  activateByNid: (nid, options) => dispatch(activateByNid(nid, options))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(BlockEditor);

--- a/src/ui/PrimitiveList.js
+++ b/src/ui/PrimitiveList.js
@@ -30,9 +30,7 @@ class Primitive extends Component {
       e.preventDefault();
       copyNodes([this.props.primitive]);
       say("copied " + this.props.primitive.toString());
-      if (this.props.primitive.element) {
-        this.props.primitive.element.focus(); // restore focus
-      }
+      this.props.primitive.element?.focus(); // restore focus
       return;
     default:
       this.props.onKeyDown(e);

--- a/src/ui/Toolbar.js
+++ b/src/ui/Toolbar.js
@@ -61,7 +61,7 @@ export default class Toolbar extends Component {
   }
 
   selectPrimitive(selectedPrimitive) {
-    if (selectedPrimitive && selectedPrimitive.element) {      
+    if (selectedPrimitive?.element) {      
       selectedPrimitive.element.focus(); // will trigger handleFocusPrimitive
     } else {
       this.setState({selectedPrimitive: selectedPrimitive});


### PR DESCRIPTION
Fixes a regression, where tabbing into the editor failed to focus the first node.

This also cleans up a lot of code in `activateByNid` and elsewhere, using option chaining and some simpler logic. Finally, the actual bug was in `commitChanges`: if the focusHint failed, the `focusId` was set to `undefined`.