### PR TITLE
[DO NOT MERGE] generate a test-utils bundle

### DIFF
--- a/webpack/bundle.config.js
+++ b/webpack/bundle.config.js
@@ -6,7 +6,8 @@ const baseConfig = require('./base.config.js');
 var configs = [
   Object.assign({}, baseConfig(), {
     entry: {
-      "CodeMirrorBlocks": './src/CodeMirrorBlocks.js'
+      "indexCodeMirrorBlocks": './src/CodeMirrorBlocks.js',
+      "test-utils": './spec/support/test-utils.js'
     },
     output: {
       path: path.resolve(__dirname, '..', "dist"),


### PR DESCRIPTION
This is for #365. With this change, test-utils can be imported by the language modules with:

```js
const testUtils = require('codemirror-blocks/dist/test-utils');
```

However, this is not good because it defeats the purpose of using a package manager like npm by bundling all the dependencies into a single 745KB `test-utils.js` file rather than declaring those dependencies in package.json.

Stay tuned for a better version.