### PR TITLE
Move test-utils to toolkit directory

### DIFF
--- a/example/editor-example.js
+++ b/example/editor-example.js
@@ -6,7 +6,7 @@ import {createDebuggingInterface} from '../lib/toolkit/debug';
 
 // HACK: expose ALL test utilities, events, etc
 // so they can be used from the browser console
-import * as t from '../spec/support/test-utils';
+import * as t from '../lib/toolkit/test-utils';
 Object.assign(window, t);
 
 //const exampleCode = smallExampleCode;

--- a/spec/activation-test.js
+++ b/spec/activation-test.js
@@ -7,7 +7,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 
 console.log('Doing activation-test.js');
 

--- a/spec/api-test.js
+++ b/spec/api-test.js
@@ -7,7 +7,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 
 console.log('Doing api-test.js');
 

--- a/spec/comment-test.js
+++ b/spec/comment-test.js
@@ -6,7 +6,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 
 console.log('Doing comment-test.js');
 

--- a/spec/drag-test.js
+++ b/spec/drag-test.js
@@ -7,7 +7,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 
 console.log('Doing drag-test.js');
 

--- a/spec/focus-test.js
+++ b/spec/focus-test.js
@@ -6,7 +6,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 
 console.log('Doing focus-test.js');
 

--- a/spec/markText-test.js
+++ b/spec/markText-test.js
@@ -6,7 +6,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 
 console.log('Doing markText-test.js');
 

--- a/spec/new-blocks-test.js
+++ b/spec/new-blocks-test.js
@@ -7,7 +7,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 const QUARANTINE_DELAY = 2000;
 
 console.log('Doing new-blocks-test.js');

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,9 +1,0 @@
-{
-  "spec_dir": "spec",
-  "spec_files": [
-    "**/*[sS]pec.js"
-  ],
-  "helpers": [
-    "helpers/**/*.js"
-  ]
-}

--- a/spec/ui/Search-test-old.js
+++ b/spec/ui/Search-test-old.js
@@ -1,6 +1,6 @@
 import example from 'codemirror-blocks/languages/example';
 import {click, keydown, pureevent, setNativeValue} from '../support/events';
-import {wait, teardown, activationSetup} from './support/test-utils';
+import {wait, teardown, activationSetup} from '../src/toolkit/test-utils';
 import {PGUP, PGDN, F3} from 'codemirror-blocks/keycode';
 
 // ms delay to let the DOM catch up before testing

--- a/spec/undo-redo-test.js
+++ b/spec/undo-redo-test.js
@@ -7,7 +7,7 @@ import {
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
   paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText
-} from '../spec/support/test-utils';
+} from '../src/toolkit/test-utils';
 
 console.log('Doing undo-redo-test.js');
 

--- a/src/toolkit/simulate.ts
+++ b/src/toolkit/simulate.ts
@@ -1,5 +1,5 @@
 import { fireEvent } from "@testing-library/react";
-//import userEvent from '@testing-library/user-event';
+import { ASTNode } from "../ast";
 
 // These exported functions simulate browser events for testing.
 // They use React's test utilities whenever possible.
@@ -11,19 +11,21 @@ import { fireEvent } from "@testing-library/react";
 //   (You can also just look at the table in the source code below.)
 // - `props` sets other properties on the event (whatever you like).
 
-export function click(node) {
+type ElementLike = Element | ASTNode
+
+export function click(node: ElementLike) {
   fireEvent.click(toElement(node));
 }
-export function mouseDown(node) {
+export function mouseDown(node: ElementLike) {
   fireEvent.mouseDown(toElement(node));
 }
-export function doubleClick(node) {
+export function doubleClick(node: ElementLike) {
   fireEvent.doubleClick(toElement(node));
 }
-export function blur(node=document.activeElement) {
+export function blur(node: ElementLike = document.activeElement) {
   fireEvent.blur(toElement(node));
 }
-export function paste(pastedString, node=document.activeElement) {
+export function paste(pastedString: string, node: ElementLike = document.activeElement) {
   var dT = null;
   try { dT = new DataTransfer();} catch(e) { console.log('ERR in paste()'); }
   var pasteEvent = new ClipboardEvent('paste', {clipboardData: dT});
@@ -31,11 +33,11 @@ export function paste(pastedString, node=document.activeElement) {
   toElement(node).dispatchEvent(pasteEvent);
   //userEvent.paste(toElement(node), pastedString);
 }
-export function cut(node=document.activeElement) {
+export function cut(node: ElementLike = document.activeElement) {
   fireEvent.cut(toElement(node));
 }
 
-function createBubbledEvent(type, props = {}) {
+function createBubbledEvent(type: string, props = {}) {
   const event = new Event(type, { bubbles: true });
   Object.assign(event, props);
   return event;
@@ -51,7 +53,7 @@ export function dragstart() {
   return ans;
 }
 
-export function dragover(node=document.activeElement) {
+export function dragover(node: ElementLike = document.activeElement) {
   toElement(node).dispatchEvent(createBubbledEvent('dragover'));
 }
 
@@ -67,7 +69,7 @@ export function mouseover() {
   return createBubbledEvent('mouseover');
 }
 
-export function dragenterSeq(node=document.activeElement) {
+export function dragenterSeq(node:ElementLike=document.activeElement) {
   //toElement(node).dispatchEvent(mouseenter());
   toElement(node).dispatchEvent(dragenter());
   toElement(node).dispatchEvent(mouseover());
@@ -85,23 +87,32 @@ export function dragend() {
   return createBubbledEvent('dragend');
 }
 
+class CustomKeydownEvent extends CustomEvent<any> {
+  which: number;
+  keyCode: number;
+  constructor(key: string) {
+    super('keydown', { bubbles: true });
+    this.which = this.keyCode = getKeyCode(key);
+  }
+}
+
 // TODO: document.activeElement isn't always a good default to dispatch to.
 // What does the _browser_ dispatch to?
-export function keyDown(key, props={}, node=document.activeElement) {
+export function keyDown(key: string, props={}, node:ElementLike=document.activeElement) {
+  node = toElement(node);
   // NOTE(Emmanuel): if it's a textarea, use native browser events
   if(node.nodeName == 'TEXTAREA') {
-    let event = new CustomEvent('keydown', {bubbles: true});
-    event.which = event.keyCode = getKeyCode(key);
+    let event = new CustomKeydownEvent(key);
     Object.assign(event, props);
     node.dispatchEvent(event);
   } else {
-    fireEvent.keyDown(toElement(node), makeKeyEvent(key, props));
+    fireEvent.keyDown(node, makeKeyEvent(key, props));
   }
 }
-export function keyPress(key, props={}, node=document.activeElement) {
+export function keyPress(key: string, props={}, node=document.activeElement) {
   fireEvent.keyPress(toElement(node), makeKeyEvent(key, props));
 }
-export function insertText(text) {
+export function insertText(text: string) {
   // TODO: can this be done via fireEvent?
   document.execCommand('insertText', false, text);
 }
@@ -110,21 +121,21 @@ export function insertText(text) {
 
 // Given a key name (like "Enter"), fill out the props properties that a key
 // event should have (like `.keyCode=13`).
-function makeKeyEvent(key, props) {
+function makeKeyEvent<T extends {}>(key: string, props: T) {
   let keyCode = getKeyCode(key);
   let eventProps = {
     which: keyCode, // deprecated
     keyCode: keyCode, // deprecated
-    key: key // Good!
+    key: key, // Good!
+    ...props
   };
-  Object.assign(eventProps, props);
   return eventProps;
 }
 
 // Convert a `.key` value to its corresponding keycode. The official table can
 // be found here:
 // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
-function getKeyCode(key) {
+function getKeyCode(key: string): number {
   // The key code for an (uppercase) letter is that letter's ascii value.
   if (key.match(/^[A-Z]$/)) {
     return key.charCodeAt(0);
@@ -162,7 +173,7 @@ function getKeyCode(key) {
 
 // Return either `node` or `node.element`, whichever is an instance of a DOM
 // element. If neither is, throw an error.
-function toElement(node) {
+function toElement(node: ElementLike): Element {
   if (node instanceof Element) {
     return node;
   }

--- a/src/toolkit/test-utils.ts
+++ b/src/toolkit/test-utils.ts
@@ -1,4 +1,4 @@
-import CodeMirrorBlocks from '../../src/CodeMirrorBlocks';
+import CodeMirrorBlocks, { Language } from '../CodeMirrorBlocks';
 import { cleanup } from "@testing-library/react";
 
 // figure out what platform we're running on
@@ -8,7 +8,7 @@ const edge = /Edge\/(\d+)/.exec(userAgent);
 const ios = !edge && /AppleWebKit/.test(userAgent) && /Mobile\/\w+/.test(userAgent);
 
 // pass along all the simulated events
-export * from './simulate';
+export * from '../../src/toolkit/simulate';
 
 // pass along useful constants
 export const mac = ios || /Mac/.test(platform);
@@ -16,7 +16,7 @@ export const cmd_ctrl = mac? { metaKey: true } : { ctrlKey: true };
 export const DELAY = 250;
 
 // pass along useful testing functions
-export async function wait(ms) {
+export async function wait(ms: number) {
   return new Promise(resolve => {
     setTimeout(resolve, ms);
   });
@@ -53,11 +53,11 @@ const fixture = `
  * or `call` (`activationSetup.call(this, pyret)`)
  * so that `this` is scoped correctly!
  */
-export function activationSetup(language) {
+export function activationSetup(language: Language): void {
   document.body.insertAdjacentHTML('afterbegin', fixture);
   const container = document.getElementById('cmb-editor');
   const cmOptions = {historyEventDelay: 50}; // since our test harness is faster than people
-  this.cmb = new CodeMirrorBlocks(
+  this.cmb = CodeMirrorBlocks(
     container, 
     { collapseAll: false, value: "", incrementalRendering: false }, 
     language, 


### PR DESCRIPTION
This PR completes issue #365.

Now language modules will be able to reuse the code from test-utils by importing from `codemirror-blocks/lib/toolkit/test-utils`, i.e.:

```js
import {wait, teardown, activationSetup} from 'codemirror-blocks/lib/toolkit/test-utils';
```