### PR TITLE
fix typescript error about non-exported return type

### DIFF
--- a/src/nodeSpec.ts
+++ b/src/nodeSpec.ts
@@ -61,7 +61,7 @@ export class NodeSpec {
     return hashObject([node.type, [...hashes], node.options.comment?.comment]);
   }
 
-  children(node: ASTNode) {
+  children(node: ASTNode): Iterable<ASTNode> {
     return new ChildrenIterator(node, this);
   }
 


### PR DESCRIPTION
This was causing the error `Return type of public method from exported class has or is using name 'ChildrenIterator' from external module ".../codemirror-blocks/src/nodeSpec" but cannot be named.`

Basically, if you export a function to make it available to other modules, but it's return type is a type that hasn't been exported, then typescript will be unhappy. This can pop up seemingly out of nowhere because typescript does so much type inference for you that you often don't need to explicitly specify the return type of a function.

There are a few ways to solve the problem in this particular case:
1. `export class ChildrenIterator` - this would allow other modules to construct a new `ChildrenIterator` themselves without having to go through the `children()` function. This however exposes an "internal implementation detail" of the nodeSpec module that maybe you don't want to expose.
2. `export type {ChildrenIterator}` - this just exports the type and not the actual class, so other modules wouldn't be able to construct new ChildrenIterator objects themselves, but they can still reference the type, allowing you to return instances of ChildrenIterator and have them be properly typed.
3. Specify a return type on `children()` that is that is more generic (and already exported somewhere) so that typescript doesn't infer the type `ChildrenIterator`. This means you get to change the internal implementation of `children()` however you like so long still return something that matches the specified return type and don't have to worry about compatibility with other modules.

I went with option 3 because it seemed like the intended interface was for `children()` to return some `Iterable` over `ASTNode`s, and not a specific instance of a specific class with specific other fields that are guaranteed to be there.