### PR TITLE
Turn on noImplicitAny in typescript config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "@types/shallowequal": "^1.1.1",
         "@types/webpack": "^5.28.0",
         "@types/webpack-bundle-analyzer": "^4.4.1",
+        "@types/webpack-dev-server": "^3.11.3",
         "eslint": "^7.32.0",
         "eslint-plugin-react": "^7.24.0",
         "typescript": "^4.3.5",
@@ -2035,6 +2036,16 @@
       "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/clean-css": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
@@ -2066,6 +2077,25 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
       "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect-history-api-fallback": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
+      "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+      "dev": true,
+      "dependencies": {
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
@@ -2099,6 +2129,29 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "node_modules/@types/glob": {
       "version": "7.1.4",
@@ -2181,6 +2234,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
+      "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul": {
       "version": "0.4.30",
       "resolved": "https://registry.npmjs.org/@types/istanbul/-/istanbul-0.4.30.tgz",
@@ -2261,6 +2323,12 @@
         "@types/karma": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2275,6 +2343,18 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "17.0.16",
@@ -2334,6 +2414,16 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/shallowequal": {
       "version": "1.1.1",
@@ -2399,6 +2489,130 @@
         "@types/node": "*",
         "tapable": "^2.2.0",
         "webpack": "^5"
+      }
+    },
+    "node_modules/@types/webpack-dev-server": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
+      "integrity": "sha512-p9B/QClflreKDeamKhBwuo5zqtI++wwb9QNG/CdIZUFtHvtaq0dWVgbtV7iMl4Sr4vWzEFj0rn16pgUFANjLPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect-history-api-fallback": "*",
+        "@types/express": "*",
+        "@types/serve-static": "*",
+        "@types/webpack": "^4",
+        "http-proxy-middleware": "^1.0.0"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/@types/webpack": {
+      "version": "4.41.30",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.30.tgz",
+      "integrity": "sha512-GUHyY+pfuQ6haAfzu4S14F+R5iGRwN6b2FRNJY7U0NilmFAqbsOfK6j1HwuLBAqwRIT+pVdNDJGJ6e8rpp0KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tapable": "^1",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "anymatch": "^3.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/http-proxy-middleware": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
+      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-proxy": "^1.17.5",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/@types/webpack-sources": {
@@ -7574,6 +7788,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -15406,6 +15632,16 @@
       "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
+    "@types/body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/clean-css": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
@@ -15436,6 +15672,25 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
       "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/connect-history-api-fallback": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
+      "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
     },
     "@types/cookie": {
       "version": "0.4.1",
@@ -15469,6 +15724,29 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.4",
@@ -15545,6 +15823,15 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "@types/http-proxy": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
+      "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/istanbul": {
@@ -15627,6 +15914,12 @@
         "@types/karma": "*"
       }
     },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -15641,6 +15934,18 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
     },
     "@types/react": {
       "version": "17.0.16",
@@ -15700,6 +16005,16 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "@types/shallowequal": {
       "version": "1.1.1",
@@ -15764,6 +16079,107 @@
         "@types/node": "*",
         "tapable": "^2.2.0",
         "webpack": "^5"
+      }
+    },
+    "@types/webpack-dev-server": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
+      "integrity": "sha512-p9B/QClflreKDeamKhBwuo5zqtI++wwb9QNG/CdIZUFtHvtaq0dWVgbtV7iMl4Sr4vWzEFj0rn16pgUFANjLPA==",
+      "dev": true,
+      "requires": {
+        "@types/connect-history-api-fallback": "*",
+        "@types/express": "*",
+        "@types/serve-static": "*",
+        "@types/webpack": "^4",
+        "http-proxy-middleware": "^1.0.0"
+      },
+      "dependencies": {
+        "@types/webpack": {
+          "version": "4.41.30",
+          "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.30.tgz",
+          "integrity": "sha512-GUHyY+pfuQ6haAfzu4S14F+R5iGRwN6b2FRNJY7U0NilmFAqbsOfK6j1HwuLBAqwRIT+pVdNDJGJ6e8rpp0KHA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/tapable": "^1",
+            "@types/uglify-js": "*",
+            "@types/webpack-sources": "*",
+            "anymatch": "^3.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
+          "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
+          "dev": true,
+          "requires": {
+            "@types/http-proxy": "^1.17.5",
+            "http-proxy": "^1.18.1",
+            "is-glob": "^4.0.1",
+            "is-plain-obj": "^3.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "@types/webpack-sources": {
@@ -20023,6 +20439,12 @@
       "requires": {
         "path-is-inside": "^1.0.2"
       }
+    },
+    "is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/shallowequal": "^1.1.1",
     "@types/webpack": "^5.28.0",
     "@types/webpack-bundle-analyzer": "^4.4.1",
+    "@types/webpack-dev-server": "^3.11.3",
     "eslint": "^7.32.0",
     "eslint-plugin-react": "^7.24.0",
     "typescript": "^4.3.5",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -307,7 +307,7 @@ export class AST {
       return (poscmp(from, n.from) == 0) && (poscmp(to, n.to) == 0)
         || (poscmp(from, srcFrom) == 0) && (poscmp(to, srcTo) == 0);
     });
-    return n || false;
+    return n || undefined;
   }
 
   /**

--- a/src/parsers/primitives.ts
+++ b/src/parsers/primitives.ts
@@ -96,7 +96,7 @@ export class PrimitiveGroup {
     }
   }
 
-  filter(search: string) {
+  filter(search: string): PrimitiveGroup {
     if (!search) {
       return this;
     }

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -15,8 +15,8 @@ declare global {
  * all instances of the AST are replaced with the source code, and
  * focusIds get replaced with node ids.
  */
- type Activity =
- | Exclude<AppAction, {ast: AST}>
+ export type Activity =
+ | Exclude<AppAction, {ast: AST} | Action<"SET_AST"> | Action<"SET_FOCUS">>
  | Action<"SET_AST"> & {code: string}
  | Action<"SET_FOCUS"> & {nid: number};
 
@@ -146,10 +146,10 @@ export const reducer = (
     result = {...state, quarantine: null};
     break;
   case 'CHANGE_QUARANTINE':
-    result = {...state, quarantine: [state.quarantine[0], state.quarantine[1], action.text]};
+    result = {...state, quarantine: [state.quarantine[0], state.quarantine[1], action.text] as Quarantine};
     break;
   case 'SET_QUARANTINE':
-    result = {...state, quarantine: [action.start, action.end, action.text]};
+    result = {...state, quarantine: [action.start, action.end, action.text] as Quarantine};
     break;
   case 'SET_ANNOUNCER':
     result = {...state, announcer: action.announcer};

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import {createStore, applyMiddleware, Store} from 'redux';
+import {createStore, applyMiddleware} from 'redux';
 import thunk, { ThunkDispatch, ThunkMiddleware } from 'redux-thunk';
 import {reducer} from './reducers';
 import type { RootState, AppAction } from './reducers';

--- a/src/toolkit/debug.ts
+++ b/src/toolkit/debug.ts
@@ -52,12 +52,20 @@ export function createDebuggingInterface(language: Language, value: string) {
     language
   );
 
-  let history,
-    lastAction,
-    currentAction = 0;
+  type JSONLog = {
+    history: typeof window.reducerActivities,
+    exception: string
+  };
+
+  let history: JSONLog['history'];
+  let lastAction: number;
+  let currentAction = 0;
 
   downloadLogButton.onclick = () => {
-    let json = { history: window.reducerActivities, exception: 'DUMMY' };
+    let json: JSONLog = {
+      history: window.reducerActivities,
+      exception: 'DUMMY'
+    };
 
     var element = document.createElement('a');
     element.setAttribute(
@@ -81,7 +89,7 @@ export function createDebuggingInterface(language: Language, value: string) {
     // parse the string, draw the actions, and set up counters
     // and UI for replaying them
     reader.onload = (readEvent) => {
-      let log;
+      let log: JSONLog;
       try {
         log = JSON.parse(readEvent.target.result.toString());
         if (!(log.exception && log.history)) throw 'Bad Log';

--- a/src/toolkit/test-utils.ts
+++ b/src/toolkit/test-utils.ts
@@ -1,4 +1,4 @@
-import CodeMirrorBlocks, { Language } from '../CodeMirrorBlocks';
+import CodeMirrorBlocks, { API, Language } from '../CodeMirrorBlocks';
 import { cleanup } from "@testing-library/react";
 // pass along all the simulated events
 export * from './simulate';
@@ -24,8 +24,8 @@ export async function wait(ms: number) {
 // wait for the editor to finish rendering, then
 // pad another 200ms 
 // NOTE(Emmanuel): 0ms causes all kinds of stuff to break
-export async function finishRender(editor) {
-  await new Promise(resolve => {
+export async function finishRender(editor:API) {
+  await new Promise<void>(resolve => {
     editor.afterDOMUpdate(resolve);  
   });
   return wait(200);

--- a/src/ui/Search.tsx
+++ b/src/ui/Search.tsx
@@ -3,7 +3,7 @@ import Dialog from '../components/Dialog';
 import {Tab, Tabs, TabList, TabPanel} from 'react-tabs';
 import 'react-tabs/style/react-tabs.less';
 import {say, getBeginCursor, getEndCursor, playSound, WRAP} from '../utils';
-import { BlockEditorComponentClass } from './BlockEditor';
+import { BlockEditorComponentClass, Search } from './BlockEditor';
 import { Searcher } from './searchers/Searcher';
 import { GetProps } from 'react-redux';
 import { ASTNode, Pos } from '../ast';
@@ -124,7 +124,7 @@ export default function attachSearch(
 
     handleSetCM = (cm: CodeMirror.Editor) => this.cm = cm
 
-    search = {
+    search: Search = {
       onSearch: this.handleActivateSearch,
       search: this.handleSearch,
       setCursor: this.handleSetCursor,

--- a/src/ui/ToggleEditor.tsx
+++ b/src/ui/ToggleEditor.tsx
@@ -49,7 +49,7 @@ declare module 'codemirror' {
     /**
      * Applies the given function to all existing selections, and calls extendSelections on the result.
      */
-    extendSelectionsBy(f: (range: CodeMirror.Position) => CodeMirror.Position): void;
+    extendSelectionsBy(f: (range: CodeMirror.Range) => CodeMirror.Position): void;
 
     /**
      * Get the value of the 'extending' flag.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "emitDeclarationOnly": true,
     // Ensure that Babel can safely transpile files in the TypeScript project
     "isolatedModules": true,
-    "outDir": "lib"
+    "outDir": "lib",
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
This change will make it harder to accidentally introduce untyped code by making sure typescript doesn't use type inference to generate the `any` type. You'll still be allowed to use `any`, you'll just have to explicitly say that a variable is `any`.

Most of this PR is just adding types where they were missing. However, there was one larger change that I made for `fakeASTEdits` and `nodeSpec`.

the `nodeSpec` stuff is a combination of a runtime typechecking library and a specification for generating fake ast nodes that look like ones from a particular language module. While it's possible to make the mutations/cloning of nodes statically typechecked using generics, it would be complicated and require changing the way nodespecs work. For example, at the moment you can define a spec for a node that looks like this:

```ts
static spec = Spec.nodeSpec([
  Spec.value('someField'),
  Spec.list('someField')
])
```

This is nonsensical because the spec for `someField` is specified twice and with different values. We can (and maybe do?) check this sort of nonsense at runtime, but typescript won't do this. To make this work with typescript, the API would have to look more like react prop types. Something like this:

```ts
static spec = Spec.nodeSpec({
  someField: Spec.value(),
  someField: Spec.list()
])
```

in this case typescript will complain about duplicate `someField`. With the object format, we can then do crazy things with typescript generics to propagate the implied types to everywhere else.

In any case, this would only be useful for language modules that are also written in typescript. In the meantime, I've added internal helper functions to `ChildSpec` called `getField` and `setField` which encapsulates the currently untyped get/set behavior. If we ever decide to support static typechecking for specs, then we'll just need to modify `getField` and `setField` to make it work in all the places where we do spec based mutation.