### PR TITLE
Rework node id generation to be more encapsulated

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,5 +1,5 @@
 import {poscmp, minpos, maxpos, posWithinNode, 
-  nodeCommentContaining, gensym, hashObject} from './utils';
+  nodeCommentContaining, genUniqueId, hashObject} from './utils';
 import * as P from 'pretty-fast-pretty-printer';
 import type CodeMirror from 'codemirror';
 import type { Comment } from './nodes';
@@ -136,7 +136,8 @@ export class AST {
       nodes.forEach((node, i) => {
         this.validateNode(node);
         // Undefined if this DID NOT come from a patched AST.
-        if (node.id === undefined) { node.id = gensym();
+        if (node.id === undefined) {
+          node.id = genUniqueId();
         }
         node.parent = parent;
         node.level = level;

--- a/src/components/DropTarget.tsx
+++ b/src/components/DropTarget.tsx
@@ -2,14 +2,12 @@ import React, {Component, createContext} from 'react';
 import {connect, ConnectedProps} from 'react-redux';
 import PropTypes from 'prop-types';
 import NodeEditable from './NodeEditable';
-import SHARED from '../shared';
 import {DropNodeTarget} from '../dnd';
 import classNames from 'classnames';
 import {AppDispatch, isErrorFree} from '../store';
-import BlockComponent from './BlockComponent';
-import {gensym} from '../utils';
+import {genUniqueId} from '../utils';
 import {drop, InsertTarget} from '../actions';
-import { AST, ASTNode, Pos } from '../ast';
+import { ASTNode, Pos } from '../ast';
 import { RootState } from '../reducers';
 
 // Provided by `Node`
@@ -72,7 +70,7 @@ export class DropTarget extends Component<{field: string}> {
   }
 
   isDropTarget: boolean = true;
-  id: string = gensym(); // generate a unique ID
+  id: string = genUniqueId(); // generate a unique ID
 
   render() {
     const value = {

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,9 +21,6 @@ export type AppStore =
     // stored somewhere else.
     onKeyDown?: (e:React.KeyboardEvent, env: InputEnv)=>void,
 
-    // set in utils.ts and used for assigning unique ids to ast nodes.
-    nodeCounter?: number,
-
     // used in say() function of util.ts
     muteAnnouncements?: boolean,
     queuedAnnouncement?: ReturnType<typeof setTimeout>,

--- a/src/toolkit/debug.ts
+++ b/src/toolkit/debug.ts
@@ -2,6 +2,7 @@ import "codemirror/lib/codemirror.css";
 import "./debug-page.less";
 import type { Language } from '../CodeMirrorBlocks';
 import CodeMirrorBlocks from '../CodeMirrorBlocks';
+import { resetUniqueIdGenerator } from "../utils";
 
 /**
  * Renders the codemirror blocks editor to the page along with some
@@ -100,7 +101,7 @@ export function createDebuggingInterface(language: Language, value: string) {
       }
       editor.setValue('');
       editor.setBlockMode(true);
-      editor.resetNodeCounter();
+      resetUniqueIdGenerator();
       history = log.history;
       history.forEach((entry) => {
         let LI = document.createElement('LI');

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -11,8 +11,7 @@ import {activateByNid, setCursor, OverwriteTarget} from '../actions';
 import {commitChanges} from '../edits/commitChanges';
 import {speculateChanges, getTempCM} from '../edits/speculateChanges';
 import DragAndDropEditor from './DragAndDropEditor';
-import {poscmp, resetNodeCounter, minpos, maxpos,
-  validateRanges, BlockError} from '../utils';
+import {poscmp, minpos, maxpos, validateRanges, BlockError} from '../utils';
 import BlockComponent from '../components/BlockComponent';
 import { defaultKeyMap, keyDown } from '../keymap';
 import {AppStore, store} from '../store';
@@ -54,11 +53,6 @@ type BlockEditorAPI = {
    * @internal
    */
   setQuarantine(start: Quarantine[0], end: Quarantine[1], txt: Quarantine[2]): void;
-
-  /**
-   * @internal
-   */
-  resetNodeCounter():void;
 
   /**
    * @internal
@@ -482,7 +476,6 @@ class BlockEditor extends Component<BlockEditorProps> {
       */
       'getQuarantine': () => withState(({quarantine}) => quarantine),
       'setQuarantine': (start, end, txt) => this.props.setQuarantine(start, end, txt),
-      'resetNodeCounter': () => resetNodeCounter(),
       'executeAction' : (action) => this.executeAction(action),
     };
     // show which APIs are unsupported

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,11 +23,25 @@ export const mac = ios || /Mac/.test(platform);
 
 // make sure we never assign the same ID to two nodes in ANY active
 // program at ANY point in time.
-store.nodeCounter = 0;
-export function gensym() {
-  return (store.nodeCounter++).toString(16);
+let nodeCounter = 0;
+/**
+ * Generates a unique string id. Note that this is only guaranteed to be
+ * unique between calls to {@link resetUniqueIdGenerator}.
+ * @internal
+ * @returns a unique string id
+ */
+export function genUniqueId() {
+  return (nodeCounter++).toString(16);
 }
-export function resetNodeCounter() { store.nodeCounter = 0; }
+
+/**
+ * Reset the state of the unique id generator. This should only be used
+ * for testing.
+ * @internal
+ */
+export function resetUniqueIdGenerator() {
+  nodeCounter = 0;
+}
 
 // Use reliable object->string library to generate a pseudohash,
 // then hash the string so we don't have giant "hashes" eating memory


### PR DESCRIPTION
The changes:
- `nodeCounter`  is no longer attached to the global store
- `gensym` has been renamed to `genUniqueId` which IMO is more explanatory
- `resetNodeCounter` is no longer being exported as part of the public API interface

This  change depends on #387, which should be reviewed first.