### PR TITLE
Enable typescript for test files and fix sourcemaps

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,6 +6,5 @@ module.exports = (config) => {
   toolkitConfig.webpack.resolve.alias = {
     'codemirror-blocks': path.resolve(__dirname, 'src'),
   };
-  toolkitConfig.files = ["spec/index.js"];
   config.set(toolkitConfig);
 };

--- a/spec/comment-test.ts
+++ b/spec/comment-test.ts
@@ -4,7 +4,7 @@ import wescheme from '../src/languages/wescheme';
 import {
   mac, cmd_ctrl, wait, removeEventListeners, teardown, activationSetup,
   click, mouseDown, mouseenter, mouseover, mouseleave, doubleClick, blur, 
-  paste, cut, copy, dragstart, dragover, drop, dragenter, dragenterSeq, 
+  paste, cut, dragstart, dragover, drop, dragenter, dragenterSeq, 
   dragend, dragleave, keyDown, keyPress, insertText, finishRender
 } from '../src/toolkit/test-utils';
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -1,3 +1,0 @@
-// require all the files in the spec folder that end with -test.js
-var context = require.context('.', true, /.-test\.js$/);
-context.keys().forEach(context);

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/src/toolkit/karma.ts
+++ b/src/toolkit/karma.ts
@@ -40,6 +40,12 @@ function getWebpackTestConfig(basePath: string, runCoverage: boolean): webpack.C
         'process.env': { NODE_ENV: JSON.stringify('development') },
       }),
     ],
+    // TODO: remove this workaround to sourcemaps being broken in
+    // karma-webpack version 5. See this github issue:
+    // https://github.com/ryanclark/karma-webpack/issues/493
+    optimization: {
+      splitChunks: false,
+    }
   };
 }
 


### PR DESCRIPTION
Turns out there is a bug in karma-webpack v5 that made sourcemaps stop working. I found the workaround in this issue: https://github.com/ryanclark/karma-webpack/issues/493.

I think in theory this might make running the tests a bit slower, but I didn't notice any difference in performance when I tried it out locally.