### PR TITLE
Make TrashCan a functional component and try to unwind use of SHARED.parse

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -66,7 +66,15 @@ export function insert(
   checkTarget(target);
   const { ast } = store.getState();
   const edits = [target.toEdit(text)];
-  performEdits("cmb:insert", ast, edits, onSuccess, onError, annt);
+  performEdits(
+    "cmb:insert",
+    ast,
+    edits,
+    SHARED.parse,
+    onSuccess,
+    onError,
+    annt
+  );
 }
 
 /**
@@ -97,7 +105,15 @@ export function delete_(nodes: ASTNode[], editWord?: string) {
     annt = createEditAnnouncement(nodes, editWord);
     say(annt);
   }
-  performEdits("cmb:delete-node", ast, edits, undefined, undefined, annt);
+  performEdits(
+    "cmb:delete-node",
+    ast,
+    edits,
+    SHARED.parse,
+    undefined,
+    undefined,
+    annt
+  );
   store.dispatch({ type: "SET_SELECTIONS", selections: [] });
 }
 
@@ -140,7 +156,7 @@ export function paste(
   pasteFromClipboard((text) => {
     const { ast } = store.getState();
     const edits = [target.toEdit(text)];
-    performEdits("cmb:paste", ast, edits, onSuccess, onError);
+    performEdits("cmb:paste", ast, edits, SHARED.parse, onSuccess, onError);
     store.dispatch({ type: "SET_SELECTIONS", selections: [] });
   });
 }
@@ -177,7 +193,7 @@ export function drop(
   // Insert or replace at the drop location, depending on what we dropped it on.
   edits.push(target.toEdit(content));
   // Perform the edits.
-  performEdits("cmb:drop-node", ast, edits, onSuccess, onError);
+  performEdits("cmb:drop-node", ast, edits, SHARED.parse, onSuccess, onError);
 
   // Assuming it did not come from the toolbar, and the srcNode was collapsed...
   // Find the matching node in the new tree and collapse it
@@ -198,7 +214,7 @@ export function dropOntoTrashCan(src: { id: string }) {
   const srcNode = src.id ? ast.getNodeById(src.id) : null; // null if dragged from toolbar
   if (!srcNode) return; // Someone dragged from the toolbar to the trash can.
   let edits = [edit_delete(srcNode)];
-  performEdits("cmb:trash-node", ast, edits);
+  performEdits("cmb:trash-node", ast, edits, SHARED.parse);
 }
 
 // Set the cursor position.

--- a/src/dnd.ts
+++ b/src/dnd.ts
@@ -11,9 +11,9 @@ import { ASTNode } from "./ast";
 import { Primitive } from "./parsers/primitives";
 import { isDummyPos } from "./utils";
 
-export const ItemTypes = {
-  NODE: "node",
-};
+export enum ItemTypes {
+  NODE = "node",
+}
 
 export const primitiveSource = {
   beginDrag(props: { primitive: Primitive }) {

--- a/src/edits/commitChanges.ts
+++ b/src/edits/commitChanges.ts
@@ -34,6 +34,7 @@ type FocusHint = (ast: AST) => ASTNode | null | "fallback";
 //   you may know from a call to `speculateChanges()`).
 export function commitChanges(
   changes: EditorChange[],
+  parse: (code: string) => AST,
   isUndoOrRedo: boolean = false,
   focusHint: FocusHint | -1 = undefined,
   astHint: AST = undefined,
@@ -49,7 +50,7 @@ export function commitChanges(
       var oldFocusNId = oldFocus ? oldFocus.nid : null;
     }
     // If we haven't already parsed the AST during speculateChanges, parse it now.
-    let newAST: AST = astHint || SHARED.parse(SHARED.cm.getValue());
+    let newAST: AST = astHint || parse(SHARED.cm.getValue());
     // Patch the tree and set the state
     newAST = patch(oldAST, newAST);
     store.dispatch({ type: "SET_AST", ast: newAST });

--- a/src/edits/performEdits.ts
+++ b/src/edits/performEdits.ts
@@ -99,6 +99,7 @@ export function performEdits(
   origin: string,
   ast: AST,
   edits: Edit[],
+  parse: (code: string) => AST,
   onSuccess: OnSuccess = (r: { newAST: AST; focusId: string }) => {},
   onError: OnError = (e: any) => {},
   annt?: string
@@ -154,7 +155,7 @@ export function performEdits(
     c.origin = origin;
   }
   // Validate the text edits.
-  let result = speculateChanges(changeArray);
+  let result = speculateChanges(changeArray, parse);
   if (result.successful) {
     try {
       // Perform the text edits, and update the ast.
@@ -166,6 +167,7 @@ export function performEdits(
       //console.log('XXX performEdits:110 calling commitChanges');
       let { newAST, focusId } = commitChanges(
         changeArray,
+        parse,
         false,
         focusHint,
         result.newAST,

--- a/src/edits/speculateChanges.ts
+++ b/src/edits/speculateChanges.ts
@@ -1,6 +1,7 @@
 import CodeMirror from "codemirror";
 import SHARED from "../shared";
 import type { EditorChange } from "codemirror";
+import type { AST } from "../ast";
 
 // TODO: For efficiency, we don't really need a full CodeMirror instance here:
 // create a mock one.
@@ -11,14 +12,17 @@ const tmpCM = CodeMirror(tmpDiv, { value: "" });
 //
 // - {successful: true, newAST}
 // - {successful: false, exception}
-export function speculateChanges(changeArr: EditorChange[]) {
+export function speculateChanges(
+  changeArr: EditorChange[],
+  parse: (code: string) => AST
+) {
   tmpCM.setValue(SHARED.cm.getValue());
   for (let c of changeArr) {
     tmpCM.replaceRange(c.text, c.from, c.to, c.origin);
   }
   let newText = tmpCM.getValue();
   try {
-    let newAST = SHARED.parse(newText);
+    let newAST = parse(newText);
     return { successful: true, newAST: newAST };
   } catch (exception) {
     return { successful: false, exception };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,5 @@
 import type CodeMirror from "codemirror";
+import type { AST } from "./ast";
 import type { Options } from "./CodeMirrorBlocks";
 
 type Shared = {
@@ -11,7 +12,7 @@ type Shared = {
     setCursor: Function;
     setCM: Function;
   };
-  parse: Function;
+  parse: (code: string) => AST;
   getExceptionMessage: Function;
   recordedMarks: Map<
     number,

--- a/src/ui/TextEditor.tsx
+++ b/src/ui/TextEditor.tsx
@@ -25,7 +25,6 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type Props = ConnectedProps<typeof connector> & {
   cmOptions?: {};
-  parse: Function;
   value: string;
   onBeforeChange?: IUnControlledCodeMirror["onBeforeChange"];
   onMount: (ed: Editor, api: API, ast: AST) => void;
@@ -58,10 +57,6 @@ class TextEditor extends Component<Props> {
         })
     );
     return api as API;
-  }
-
-  componentDidMount() {
-    SHARED.parse = this.props.parse;
   }
 
   render() {

--- a/src/ui/ToggleEditor.tsx
+++ b/src/ui/ToggleEditor.tsx
@@ -343,6 +343,8 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
     this.toolbarRef = createRef();
 
     SHARED.recordedMarks = new Map();
+    SHARED.parse = this.props.language.parse;
+
     this.eventHandlers = {}; // blank event-handler record
 
     this.state.code = props.initialCode;
@@ -515,7 +517,7 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
         try {
           let oldCode = SHARED.cm.getValue();
           oldCode.match(/\s+$/); // match ending whitespace
-          oldAst = SHARED.parse(oldCode); // parse the code (WITH annotations)
+          oldAst = this.props.language.parse(oldCode); // parse the code (WITH annotations)
         } catch (err) {
           console.error(err);
           try {
@@ -526,7 +528,7 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
         }
         try {
           code = oldAst.toString() + (WS ? WS[0] : ""); // pretty-print and restore whitespace
-          this.ast = SHARED.parse(code); // parse the pretty-printed (PP) code
+          this.ast = this.props.language.parse(code); // parse the pretty-printed (PP) code
         } catch (e) {
           console.error("COULD NOT PARSE PRETTY-PRINTED CODE FROM:\n", oldAst);
           console.error("PRETTY-PRINTED CODE WAS", oldAst.toString());
@@ -605,7 +607,6 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
     return (
       <TextEditor
         cmOptions={{ ...defaultCmOptions, ...this.props.cmOptions }}
-        parse={this.props.language.parse}
         value={this.state.code}
         onMount={this.handleEditorMounted}
         api={this.props.api}
@@ -623,7 +624,6 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
     return (
       <UpgradedBlockEditor
         cmOptions={{ ...defaultCmOptions, ...this.props.cmOptions }}
-        parse={this.props.language.parse}
         value={this.state.code}
         onMount={this.handleEditorMounted}
         api={this.props.api}

--- a/src/ui/TrashCan.tsx
+++ b/src/ui/TrashCan.tsx
@@ -1,48 +1,22 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { DropNodeTarget } from "../dnd";
+import React from "react";
+import { ItemTypes } from "../dnd";
 import { dropOntoTrashCan } from "../actions";
-import { ConnectDropTarget } from "react-dnd";
+import { useDrop } from "react-dnd";
 require("./TrashCan.less");
 
-type Props = {
-  connectDropTarget: ConnectDropTarget;
-};
+export default function TrashCan() {
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept: ItemTypes.NODE,
+    drop: (item: { id: string }) => {
+      dropOntoTrashCan(item);
+    },
+    collect: (monitor) => ({ isOver: monitor.isOver() }),
+  }));
 
-class TrashCan extends Component<Props> {
-  state = {
-    isOverTrashCan: false,
-  };
-
-  handleDragEnter = () => {
-    this.setState({ isOverTrashCan: true });
-  };
-
-  handleDragLeave = () => {
-    this.setState({ isOverTrashCan: false });
-  };
-
-  handleDragOver = (event: React.MouseEvent) => {
-    event.preventDefault();
-  };
-
-  render() {
-    let classNames = "TrashCan" + (this.state.isOverTrashCan ? " over" : "");
-    return this.props.connectDropTarget(
-      <div
-        className={classNames}
-        aria-hidden={true}
-        onDragEnter={this.handleDragEnter}
-        onDragLeave={this.handleDragLeave}
-        onDrop={this.handleDragLeave}
-        onDragOver={this.handleDragOver}
-      >
-        🗑️
-      </div>
-    );
-  }
+  const classNames = "TrashCan" + (isOver ? " over" : "");
+  return (
+    <div ref={drop} className={classNames} aria-hidden={true}>
+      🗑️
+    </div>
+  );
 }
-
-export default DropNodeTarget(function (monitor) {
-  return dropOntoTrashCan(monitor.getItem());
-})(TrashCan);


### PR DESCRIPTION
Just doing some more refactoring to try and clean up this tangle.

Now SHARED.parse only gets initialized inside ToggleEditor, and is now only accessed by redux actions,  longer being accessed except from a react component or a redux action and the top-level editor components.

Also in this PR is refactoring of TrashCan to be a functional component, which uses the react-dnd hooks api. It's a lot more compact.