### PR TITLE
Use react-contenteditable instead of our own solution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10633,6 +10633,15 @@
       "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
       "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
     },
+    "react-contenteditable": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.3.6.tgz",
+      "integrity": "sha512-61+Anbmzggel1sP7nwvxq3d2woD3duR5R89RoLGqKan1A+nruFIcmLjw2F+qqk70AyABls0BDKzE1vqS1UIF1g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "prop-types": "^15.7.1"
+      }
+    },
     "react-dnd": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "raw-loader": "^4.0.2",
     "react": "^17.0.2",
     "react-codemirror2": "^7.2.1",
+    "react-contenteditable": "^3.3.6",
     "react-dnd": "^14.0.3",
     "react-dnd-html5-backend": "^14.0.1",
     "react-dom": "^17.0.2",

--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -1,11 +1,24 @@
 import React, { Component } from "react";
+import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
+import type { Props as ContentEditableProps } from "react-contenteditable";
 
 /**
  * Single line contentEditable
  *
  * This component creates a span with contenteditable
  * It only supports one line content, so users are expected
- * to pass in onKeyDown and intercept the enter key
+ * to pass in onKeyDown and intercept the enter key.
+ *
+ * There are a number of tricky issues when using content editable
+ * html components with react, which is why we use the react-contenteditable
+ * library. In short, a naive use of contenteditable in react causes the
+ * caret position to change on every update.
+ * See this stackoverflow answer for an overview:
+ * https://stackoverflow.com/questions/22677931/react-js-onchange-event-for-contenteditable/27255103#27255103
+ *
+ * To test this component manually, fire up the block editor and double click
+ * on a leaf node to edit it. Typing in the leaf node should not result in
+ * the caret moving to the beginning on every keypress.
  */
 
 // use a plaintext INPUT elt to avoid characters being
@@ -16,9 +29,16 @@ function getInnerHTML(txt: string) {
   return el.value;
 }
 
-export type ContentEditableProps = Omit<
-  React.ComponentPropsWithoutRef<"span">,
-  "onChange"
+export type Props = Omit<
+  ContentEditableProps,
+  | "html"
+  | "onChange"
+  | "tagName"
+  | "spellCheck"
+  | "onKeyDown"
+  | "onPaste"
+  | "innerRef"
+  | "ref"
 > & {
   onChange?: (e: string) => void;
   onKeyDown?: (e: React.KeyboardEvent) => void;
@@ -26,7 +46,7 @@ export type ContentEditableProps = Omit<
   value?: string;
 };
 
-export default class ContentEditable extends Component<ContentEditableProps> {
+export default class OneLineContentEditable extends Component<Props> {
   static defaultProps = {
     onChange: () => {},
     onKeyDown: () => {},
@@ -34,15 +54,15 @@ export default class ContentEditable extends Component<ContentEditableProps> {
     value: "",
   };
 
-  eltRef: React.RefObject<HTMLSpanElement>;
+  eltRef: React.RefObject<HTMLElement>;
 
-  constructor(props: ContentEditableProps) {
+  constructor(props: Props) {
     super(props);
     this.eltRef = React.createRef();
   }
 
-  handleChange = () => {
-    this.props.onChange(this.eltRef.current.textContent);
+  handleChange = (event: ContentEditableEvent) => {
+    this.props.onChange(event.target.value);
   };
 
   handleKeyDown = (e: React.KeyboardEvent) => {
@@ -67,15 +87,15 @@ export default class ContentEditable extends Component<ContentEditableProps> {
   render() {
     const { value, itDidMount, onChange, ...props } = this.props;
     return (
-      <span
+      <ContentEditable
         {...props}
-        ref={this.eltRef}
-        dangerouslySetInnerHTML={{ __html: getInnerHTML(value) }}
-        contentEditable={"plaintext-only" as any}
+        html={getInnerHTML(value)}
+        onChange={this.handleChange}
+        tagName="span"
         spellCheck={false}
-        onInput={this.handleChange}
         onKeyDown={this.handleKeyDown}
         onPaste={this.handlePaste}
+        innerRef={this.eltRef}
       />
     );
   }

--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -1,6 +1,8 @@
 import React, { Component, ReactElement } from "react";
 import { connect } from "react-redux";
-import ContentEditable, { ContentEditableProps } from "./ContentEditable";
+import ContentEditable, {
+  Props as ContentEditableProps,
+} from "./ContentEditable";
 import SHARED from "../shared";
 import classNames, { Argument as ClassNamesArgument } from "classnames";
 import { insert, activateByNid, Target } from "../actions";


### PR DESCRIPTION
I found the reason why we were using `shouldComponentUpdate` and it has to do with some subtle things in react's update model and contenteditable dom nodes. See https://stackoverflow.com/questions/22677931/react-js-onchange-event-for-contenteditable/27255103#27255103.

This PR switches us to using the I've switched us to using the [react-contenteditable](https://github.com/lovasoa/react-contenteditable) npm package which implements these intricacies, is well maintained, used by many, and has actual unit tests for this subtle behavior.