### PR TITLE
use React.forwardRef in favor of itDidMount callback

### DIFF
--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -42,24 +42,17 @@ export type Props = Omit<
 > & {
   onChange?: (e: string) => void;
   onKeyDown?: (e: React.KeyboardEvent) => void;
-  itDidMount?: (el: HTMLElement) => void;
   value?: string;
 };
 
-export default class OneLineContentEditable extends Component<Props> {
+class OneLineContentEditable extends Component<
+  Props & { forwardedRef: React.ForwardedRef<HTMLElement> }
+> {
   static defaultProps = {
     onChange: () => {},
     onKeyDown: () => {},
-    itDidMount: () => {},
     value: "",
   };
-
-  eltRef: React.RefObject<HTMLElement>;
-
-  constructor(props: Props) {
-    super(props);
-    this.eltRef = React.createRef();
-  }
 
   handleChange = (event: ContentEditableEvent) => {
     this.props.onChange(event.target.value);
@@ -80,12 +73,8 @@ export default class OneLineContentEditable extends Component<Props> {
     document.execCommand("insertText", false, text);
   };
 
-  componentDidMount() {
-    this.props.itDidMount(this.eltRef.current);
-  }
-
   render() {
-    const { value, itDidMount, onChange, ...props } = this.props;
+    const { value, onChange, forwardedRef, ...props } = this.props;
     return (
       <ContentEditable
         {...props}
@@ -95,8 +84,12 @@ export default class OneLineContentEditable extends Component<Props> {
         spellCheck={false}
         onKeyDown={this.handleKeyDown}
         onPaste={this.handlePaste}
-        innerRef={this.eltRef}
+        innerRef={forwardedRef}
       />
     );
   }
 }
+
+export default React.forwardRef<HTMLElement, Props>((props, ref) => (
+  <OneLineContentEditable {...props} forwardedRef={ref} />
+));

--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -36,7 +36,7 @@ type Props = ContentEditableProps & {
 
 class NodeEditable extends Component<Props> {
   ignoreBlur: boolean;
-  element: HTMLElement;
+  element = React.createRef<HTMLElement>();
   pendingTimeout?: afterDOMUpdateHandle;
 
   saveEdit = (e: React.SyntheticEvent) => {
@@ -115,6 +115,7 @@ class NodeEditable extends Component<Props> {
   };
 
   componentDidMount() {
+    this.setSelection(this.props.isInsertion);
     const text = this.props.value || this.props.initialValue || "";
     const annt =
       (this.props.isInsertion ? "inserting" : "editing") + ` ${text}`;
@@ -142,17 +143,12 @@ class NodeEditable extends Component<Props> {
     cancelAfterDOMUpdate(this.pendingTimeout);
     this.pendingTimeout = setAfterDOMUpdate(() => {
       const range = document.createRange();
-      range.selectNodeContents(this.element);
+      range.selectNodeContents(this.element.current);
       if (isCollapsed) range.collapse(false);
       window.getSelection().removeAllRanges();
       window.getSelection().addRange(range);
-      this.element.focus();
+      this.element.current.focus();
     });
-  };
-
-  contentEditableDidMount = (el: HTMLElement) => {
-    this.element = el;
-    this.setSelection(this.props.isInsertion);
   };
 
   render() {
@@ -174,7 +170,7 @@ class NodeEditable extends Component<Props> {
         {...contentEditableProps}
         className={classNames(classes)}
         role="textbox"
-        itDidMount={this.contentEditableDidMount}
+        ref={this.element}
         onChange={onChange}
         onBlur={this.handleBlur}
         onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
We were using this `itDidMount` prop to pass the inner span element to the parent component. But this behavior is already supported by react ref objects using [React.forwardRef](https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components), which also ensures that the code that uses the element is always using the latest one (via the `RefObject.current` property).