### PR TITLE
Fix tests 

### DIFF
--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -142,12 +142,20 @@ class NodeEditable extends Component<Props> {
   setSelection = (isCollapsed: boolean) => {
     cancelAfterDOMUpdate(this.pendingTimeout);
     this.pendingTimeout = setAfterDOMUpdate(() => {
+      const element = this.element.current;
+      if (!element) {
+        // element has been unmounted already, nothing to do.
+        return;
+      }
       const range = document.createRange();
-      range.selectNodeContents(this.element.current);
+      range.selectNodeContents(element);
       if (isCollapsed) range.collapse(false);
-      window.getSelection().removeAllRanges();
-      window.getSelection().addRange(range);
-      this.element.current.focus();
+      const selection = window.getSelection();
+      if (selection) {
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+      element.focus();
     });
   };
 


### PR DESCRIPTION
Now that we are using refs, react can tell us about whether the element we are referring to still exists or not, which we should use to avoid doing unnecessary work. The tests started failing because we were not doing this check.