### PR TITLE
Remove unnecessary use of setAfterDOMUpdate in NodeEditable

### DIFF
--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -111,7 +111,9 @@ class NodeEditable extends Component<Props> {
         console.log(errorText);
         this.ignoreBlur = false;
         setErrorId(target.node ? target.node.id : "editing");
-        this.setSelection(false);
+        if (this.element.current) {
+          selectElement(this.element.current, false);
+        }
       };
       insert(value, target, onSuccess, onError, annt);
     });
@@ -138,7 +140,14 @@ class NodeEditable extends Component<Props> {
   };
 
   componentDidMount() {
-    this.setSelection(this.props.isInsertion);
+    this.pendingTimeout = setAfterDOMUpdate(() => {
+      const element = this.element.current;
+      if (!element) {
+        // element has been unmounted already, nothing to do.
+        return;
+      }
+      selectElement(element, this.props.isInsertion);
+    });
     const text = this.props.value || this.props.initialValue || "";
     const annt =
       (this.props.isInsertion ? "inserting" : "editing") + ` ${text}`;
@@ -160,18 +169,6 @@ class NodeEditable extends Component<Props> {
   handleBlur = (e: React.FocusEvent) => {
     if (this.ignoreBlur) return;
     this.saveEdit(e);
-  };
-
-  setSelection = (isCollapsed: boolean) => {
-    cancelAfterDOMUpdate(this.pendingTimeout);
-    this.pendingTimeout = setAfterDOMUpdate(() => {
-      const element = this.element.current;
-      if (!element) {
-        // element has been unmounted already, nothing to do.
-        return;
-      }
-      selectElement(element, isCollapsed);
-    });
   };
 
   render() {

--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -14,6 +14,10 @@ import { AST } from "../ast";
 import { setAfterDOMUpdate, cancelAfterDOMUpdate } from "../utils";
 import type { afterDOMUpdateHandle } from "../utils";
 
+function suppressEvent(e: React.SyntheticEvent) {
+  e.stopPropagation();
+}
+
 type Props = ContentEditableProps & {
   // created by redux mapStateToProps
   initialValue: string;
@@ -110,10 +114,6 @@ class NodeEditable extends Component<Props> {
     }
   };
 
-  suppressEvent = (e: React.SyntheticEvent) => {
-    e.stopPropagation();
-  };
-
   componentDidMount() {
     this.setSelection(this.props.isInsertion);
     const text = this.props.value || this.props.initialValue || "";
@@ -184,9 +184,9 @@ class NodeEditable extends Component<Props> {
         onKeyDown={this.handleKeyDown}
         // trap mousedown, clicks and doubleclicks, to prevent focus change, or
         // parent nodes from toggling collapsed state
-        onMouseDown={this.suppressEvent}
-        onClick={this.suppressEvent}
-        onDoubleClick={this.suppressEvent}
+        onMouseDown={suppressEvent}
+        onClick={suppressEvent}
+        onDoubleClick={suppressEvent}
         aria-label={text}
         value={text}
       />

--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -18,6 +18,29 @@ function suppressEvent(e: React.SyntheticEvent) {
   e.stopPropagation();
 }
 
+/**
+ * Make the browser select the given html element and focus it
+ *
+ * @param element the html element to select
+ * @param shouldCollapse whether or not to force the browser
+ *        to collapse the selection to the end of the elements range.
+ */
+function selectElement(element: HTMLElement, shouldCollapse: boolean) {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  if (shouldCollapse) {
+    range.collapse(false);
+  }
+  const selection = window.getSelection();
+  if (selection) {
+    // window.getSelection can return null in firefox when rendered
+    // inside a hidden iframe: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#return_value
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+  element.focus();
+}
+
 type Props = ContentEditableProps & {
   // created by redux mapStateToProps
   initialValue: string;
@@ -147,15 +170,7 @@ class NodeEditable extends Component<Props> {
         // element has been unmounted already, nothing to do.
         return;
       }
-      const range = document.createRange();
-      range.selectNodeContents(element);
-      if (isCollapsed) range.collapse(false);
-      const selection = window.getSelection();
-      if (selection) {
-        selection.removeAllRanges();
-        selection.addRange(range);
-      }
-      element.focus();
+      selectElement(element, isCollapsed);
     });
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export const mac = ios || /Mac/.test(platform);
  * - If an extraDelay is passed, the inner timeout waits Xms after the render cycle
  */
 export type afterDOMUpdateHandle = {
-  raf?: number;
+  raf: number;
   timeout?: ReturnType<typeof setTimeout>;
 };
 export function setAfterDOMUpdate(
@@ -48,10 +48,13 @@ export function setAfterDOMUpdate(
 }
 
 export function cancelAfterDOMUpdate(handle: afterDOMUpdateHandle): void {
-  if (!handle || !handle.timeout) {
+  if (!handle) {
     return;
   }
   cancelAnimationFrame(handle.raf);
+  if (!handle.timeout) {
+    return;
+  }
   clearTimeout(handle.timeout);
 }
 


### PR DESCRIPTION
also fixed a bug with cancelAfterDOMUpdate never cancelling the requestAnimationFrame callback.

Wherever we use `setAfterDOMUpdate`, there should be a comment explaining why it is necessary. I bet there are a lot of places (i found one in this PR) where it is not necessary, and having it just causes subtle race conditions to occur.