### PR TITLE
Enable linting of typescript files in github lint check workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: wearerequired/lint-action@v1
         with:
           eslint: true
-          eslint_extensions: js
+          eslint_extensions: js,jsx,ts,tsx
           eslint_args: src spec example
 
       # Make sure prettier was run on any changes

--- a/src/ui/Toolbar.tsx
+++ b/src/ui/Toolbar.tsx
@@ -54,10 +54,9 @@ var Toolbar = (props: Props) => {
         return;
       case "Esc":
         toolbarRef.current.focus(); // focus, then fall-through
-      default:
-        event.stopPropagation();
-        return;
+        break;
     }
+    event.stopPropagation();
   };
 
   // if a primitive is selected, make a block node for it


### PR DESCRIPTION
Looks like it was set to just js files before and I forgot to update it when moving everything to typescript.