### PR TITLE
BlockEditor to hooks

### DIFF
--- a/src/ui/Search.tsx
+++ b/src/ui/Search.tsx
@@ -4,14 +4,14 @@ import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import "react-tabs/style/react-tabs.less";
 import { getBeginCursor, getEndCursor, playSound, WRAP } from "../utils";
 import { say } from "../announcer";
-import { BlockEditorComponentClass, Search } from "./BlockEditor";
+import BlockEditor, { Search } from "./BlockEditor";
 import { Searcher } from "./searchers/Searcher";
 import { GetProps } from "react-redux";
 import { ASTNode, Pos } from "../ast";
 import { RootState } from "../reducers";
 
 export default function attachSearch(
-  Editor: BlockEditorComponentClass,
+  Editor: typeof BlockEditor,
   searchModes: Searcher<any, any>[]
 ) {
   const settings = searchModes.reduce((acc, searchMode, i) => {
@@ -19,7 +19,7 @@ export default function attachSearch(
     return acc;
   }, {} as { [index: number]: unknown });
 
-  type Props = GetProps<BlockEditorComponentClass> & {
+  type Props = GetProps<typeof BlockEditor> & {
     appElement: HTMLElement;
   };
 


### PR DESCRIPTION
This one is definitely a learning curve. I first converted `ToplevelBlockEditable` without incident (all tests pass!), and then tackled `BlockEditor` itself. This included unwrapping the mapDispatch/mapState layer, and replacing the component lifecycle methods with `useEffect`.

I wasn't able to test this out in pieces - compilation and type errors persisted until ALL of the change was complete - but now that it runs it looks like I've messed up the translation from `mapStateToProps`. Hoping @pcardune can point me in the right direction here.