### PR TITLE
Get a bit closer to making Node a functional component

### DIFF
--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import ContentEditable, {
   Props as ContentEditableProps,
@@ -41,7 +41,7 @@ function selectElement(element: HTMLElement, shouldCollapse: boolean) {
 
 type Props = ContentEditableProps & {
   target?: Target;
-  children?: ReactElement;
+  children?: React.ReactNode;
   isInsertion: boolean;
   value?: string | null;
   onChange?: (e: string) => void;

--- a/src/keymap.tsx
+++ b/src/keymap.tsx
@@ -66,7 +66,15 @@ export type InputEnv = {
       nid: number,
       options?: { allowMove: boolean; record?: boolean }
     ) => void;
-  } & Partial<EnhancedNodeProps>;
+
+    // the following are from Node.tsx
+    collapse?: (id: string) => void;
+    uncollapse?: (id: string) => void;
+    setCursor?: (cur: CodeMirror.Position) => void;
+    isCollapsed?: boolean;
+    expandable?: boolean;
+    normallyEditable?: boolean;
+  };
   node?: ASTNode;
 
   // these get tacked on by the keyDown function


### PR DESCRIPTION
So in this PR, I took the node class, which now consisted of just a render method and some lifecycle methods, and made it into a functional component, but I got stymied in a couple places.

1. the class component extends `BlockComponent` which has a shouldComponentUpdate method. Something is depending on the exact implementation of that shouldComponentUpdate method (i.e. it's not purely a performance enhancement), and the tests fail when I try to remove it.
2. the `componentDidUpdate` lifecycle method depends on the previous props, which doesn't really map onto the way `useEffect()` works.

To deal with the above issues, I left in a `BlockComponentNode` component that wraps the functional `Node` component to get the lifecycle methods. This is not great and I'd like to figure out how to not do this.

The lifecycle methods of the `BlockComponentNode` component also still depend on data from the redux store, so I left the `ConnectedNode` functional component, which uses `useSelector()` to grab the necessary data.
