### PR TITLE
Remove some dead stuff from SHARED global

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -321,17 +321,25 @@ function checkTarget(target: Target) {
   }
 }
 
+// create a hidden buffer, for use with copy/cut/paste
+const buffer = document.createElement("textarea");
+buffer.ariaHidden = "true";
+buffer.tabIndex = -1;
+buffer.style.opacity = "0";
+buffer.style.height = "1px";
+document.body.appendChild(buffer);
+
 function copyToClipboard(text: string) {
-  SHARED.buffer.value = text;
-  SHARED.buffer.select();
+  buffer.value = text;
+  buffer.select();
   document.execCommand("copy");
 }
 
 function pasteFromClipboard(done: (value: string) => void) {
-  SHARED.buffer.value = "";
-  SHARED.buffer.focus();
+  buffer.value = "";
+  buffer.focus();
   setTimeout(() => {
-    done(SHARED.buffer.value);
+    done(buffer.value);
   }, 50);
 }
 

--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -110,9 +110,8 @@ const NodeEditable = (props: Props) => {
         setErrorId("");
         say(annt);
       };
-      const onError = () => {
-        const errorText = SHARED.getExceptionMessage(e);
-        console.log(errorText);
+      const onError = (e: any) => {
+        console.error(e);
         setErrorId(target.node ? target.node.id : "editing");
         if (element.current) {
           selectElement(element.current, false);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -13,7 +13,6 @@ type Shared = {
     setCM: Function;
   };
   parse: (code: string) => AST;
-  getExceptionMessage: Function;
 };
 
 export default {} as Shared;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -5,7 +5,6 @@ import type { Options } from "./CodeMirrorBlocks";
 type Shared = {
   cm: CodeMirror.Editor;
   options: Options;
-  buffer: HTMLTextAreaElement;
   search: {
     onSearch: Function;
     search: Function;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -14,14 +14,6 @@ type Shared = {
   };
   parse: (code: string) => AST;
   getExceptionMessage: Function;
-  recordedMarks: Map<
-    number,
-    {
-      from: CodeMirror.Position;
-      to: CodeMirror.Position;
-      options: CodeMirror.TextMarkerOptions;
-    }
-  >;
 };
 
 export default {} as Shared;

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -867,7 +867,6 @@ class BlockEditor extends Component<BlockEditorProps> {
   };
 
   componentWillUnmount() {
-    SHARED.buffer.remove();
     cancelAfterDOMUpdate(this.pendingTimeout);
   }
 
@@ -877,14 +876,7 @@ class BlockEditor extends Component<BlockEditorProps> {
     // TODO: pass these with a React Context or something sensible like that.
     SHARED.options = options;
     SHARED.search = search;
-    // create a hidden buffer, for use with copy/cut/paste
-    const clipboardBuffer = document.createElement("textarea");
-    (clipboardBuffer as $TSFixMe).ariaHidden = true;
-    clipboardBuffer.tabIndex = -1;
-    clipboardBuffer.style.opacity = "0";
-    clipboardBuffer.style.height = "1px";
-    SHARED.buffer = clipboardBuffer;
-    document.body.appendChild(SHARED.buffer);
+
     this.pendingTimeout = setAfterDOMUpdate(this.refreshCM() as $TSFixMe);
   }
 

--- a/src/ui/ToggleEditor.tsx
+++ b/src/ui/ToggleEditor.tsx
@@ -528,11 +528,13 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
           oldAst = this.props.language.parse(oldCode); // parse the code (WITH annotations)
         } catch (err) {
           console.error(err);
+          let message = "";
           try {
-            throw SHARED.getExceptionMessage(err);
+            message = this.props.language.getExceptionMessage(err);
           } catch (e) {
-            throw "The parser failed, and the error could not be retrieved";
+            message = "The parser failed, and the error could not be retrieved";
           }
+          throw message;
         }
         try {
           code = oldAst.toString() + (WS ? WS[0] : ""); // pretty-print and restore whitespace

--- a/src/ui/ToggleEditor.tsx
+++ b/src/ui/ToggleEditor.tsx
@@ -337,12 +337,20 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
   ast?: AST;
   newAST?: AST;
 
+  private recordedMarks: Map<
+    number,
+    {
+      from: CodeMirror.Position;
+      to: CodeMirror.Position;
+      options: CodeMirror.TextMarkerOptions;
+    }
+  > = new Map();
+
   constructor(props: ToggleEditorProps) {
     super(props);
 
     this.toolbarRef = createRef();
 
-    SHARED.recordedMarks = new Map();
     SHARED.parse = this.props.language.parse;
 
     this.eventHandlers = {}; // blank event-handler record
@@ -428,7 +436,7 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
     // once the DOM has loaded, reconstitute any marks and render them
     // see https://stackoverflow.com/questions/26556436/react-after-render-code/28748160#28748160
     this.pendingTimeout = setAfterDOMUpdate(() => {
-      SHARED.recordedMarks.forEach(
+      this.recordedMarks.forEach(
         (m: { options: CodeMirror.TextMarkerOptions }, k: number) => {
           let node = ast.getNodeByNId(k);
           if (node) {
@@ -449,7 +457,7 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
    * the editor mounts.
    */
   recordMarks(oldAST: AST) {
-    SHARED.recordedMarks.clear();
+    this.recordedMarks.clear();
     (SHARED.cm as CodeMirror.Editor)
       .getAllMarks()
       .filter((m) => !m.BLOCK_NODE_ID && m.type !== "bookmark")
@@ -477,7 +485,7 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
           throw new Error("Could not find node " + oldNode.nid + " in new AST");
         }
         const { from, to } = newNode;
-        SHARED.recordedMarks.set(oldNode.nid, {
+        this.recordedMarks.set(oldNode.nid, {
           from: from,
           to: to,
           options: {


### PR DESCRIPTION
`recordedMarks` was only ever used by ToggleEditor, so I moved it to be an instance property on ToggleEditor. It should probably be stored in some different way but my goal for the time being was just to get it off SHARED.

`getExceptionMessage` was just broken. It never got set and was accessed in two different places. It looks like it was replaced with a property of the same name on the language definition object, but then wasn't removed from the SHARED object. As a result, the error messaging was broken. I fixed it. There weren't any tests for this, but it seems like there should be since this is very much a user facing feature. What's the best place to add tests for parse error handling?

`buffer` was only used by actions.ts for copy/paste handling, so I moved the creation and storage of it to be local to that file.