### PR TITLE
Remove 100ms delay in tests

### DIFF
--- a/src/toolkit/test-utils.ts
+++ b/src/toolkit/test-utils.ts
@@ -1,7 +1,6 @@
 import CodeMirrorBlocks, { API, Language } from "../CodeMirrorBlocks";
 import { cleanup } from "@testing-library/react";
-import { setAfterDOMUpdate, cancelAfterDOMUpdate } from "../utils";
-import type { afterDOMUpdateHandle } from "../utils";
+import { afterAllDOMUpdates } from "../utils";
 // pass along all the simulated events
 export * from "./simulate";
 
@@ -23,10 +22,10 @@ export async function wait(ms: number) {
   });
 }
 
-// wait for the editor to finish rendering, then pad another 100ms
-// NOTE(Emmanuel): insufficient padding causes all kinds of stuff to break
-export async function finishRender(editor: API) {
-  return new Promise<void>((resolve) => setAfterDOMUpdate(resolve, 100));
+// wait for the editor to finish rendering and for any
+// other async DOM tasks to finish
+export function finishRender(editor: API) {
+  return afterAllDOMUpdates();
 }
 
 export function removeEventListeners() {

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -877,11 +877,11 @@ class BlockEditor extends Component<BlockEditorProps> {
     SHARED.options = options;
     SHARED.search = search;
 
-    this.pendingTimeout = setAfterDOMUpdate(this.refreshCM() as $TSFixMe);
+    this.refreshCM();
   }
 
   componentDidUpdate() {
-    this.pendingTimeout = setAfterDOMUpdate(this.refreshCM() as $TSFixMe);
+    this.refreshCM();
   }
 
   /**


### PR DESCRIPTION
Now calls to `afterDOMUpdate()` keep track of all uncompleted callbacks, allowing you to wait for all uncompleted callbacks to finish.

This should take care of the first todo in #391