### PR TITLE
Bring some sanity to keyDown event handling

### DIFF
--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -93,6 +93,8 @@ const Node = (
   };
 
   const keydownEnv: InputEnv = {
+    node: props.node,
+
     isLocked,
     handleMakeEditable,
     setLeft: () => {
@@ -109,8 +111,15 @@ const Node = (
       }
       return !!dropTargetId;
     },
-    // TODO(pcardune): don't blindly pass in all props
-    props: { ...props, ...redux },
+    normallyEditable: props.normallyEditable,
+    expandable: props.expandable,
+    isCollapsed: props.isCollapsed,
+
+    dispatch: redux.dispatch,
+    activateByNid: redux.activateByNid,
+    collapse: redux.collapse,
+    uncollapse: redux.uncollapse,
+    setCursor: redux.setCursor,
   };
   const handleClick = (e: React.MouseEvent) => {
     const { inToolbar, normallyEditable } = props;

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, useEffect, useState } from "react";
+import React, { HTMLAttributes } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { ASTNode } from "../ast";
 import { drop, activateByNid, setCursor, ReplaceNodeTarget } from "../actions";
@@ -79,18 +79,6 @@ const Node = (
   };
 
   const dispatch: AppDispatch = useDispatch();
-  const redux = {
-    dispatch,
-    collapse: (id: string) => dispatch({ type: "COLLAPSE", id }),
-    uncollapse: (id: string) => dispatch({ type: "UNCOLLAPSE", id }),
-    setCursor: (cur: CodeMirror.Position) => dispatch(setCursor(cur)),
-    activateByNid: (
-      nid: number,
-      options: { allowMove?: boolean; record?: boolean }
-    ) => dispatch(activateByNid(nid, options)),
-    setEditable: (id: string, bool: boolean) =>
-      dispatch({ type: "SET_EDITABLE", id, bool }),
-  };
 
   const keydownEnv: InputEnv = {
     isNodeEnv: true,
@@ -101,14 +89,14 @@ const Node = (
     setLeft: () => {
       const dropTargetId = findAdjacentDropTargetId(props.node, true);
       if (dropTargetId) {
-        redux.setEditable(dropTargetId, true);
+        dispatch({ type: "SET_EDITABLE", id: dropTargetId, bool: true });
       }
       return !!dropTargetId;
     },
     setRight: () => {
       const dropTargetId = findAdjacentDropTargetId(props.node, false);
       if (dropTargetId) {
-        redux.setEditable(dropTargetId, true);
+        dispatch({ type: "SET_EDITABLE", id: dropTargetId, bool: true });
       }
       return !!dropTargetId;
     },
@@ -116,11 +104,7 @@ const Node = (
     expandable: props.expandable,
     isCollapsed: props.isCollapsed,
 
-    dispatch: redux.dispatch,
-    activateByNid: redux.activateByNid,
-    collapse: redux.collapse,
-    uncollapse: redux.uncollapse,
-    setCursor: redux.setCursor,
+    dispatch,
   };
   const handleClick = (e: React.MouseEvent) => {
     const { inToolbar, normallyEditable } = props;
@@ -137,16 +121,16 @@ const Node = (
     if (!isErrorFree()) return; // TODO(Oak): is this the best way?
     const { ast } = store.getState();
     const currentNode = ast.getNodeById(props.node.id);
-    redux.activateByNid(currentNode.nid, { allowMove: false });
+    dispatch(activateByNid(currentNode.nid, { allowMove: false }));
   };
 
   const handleDoubleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (props.inToolbar) return;
     if (props.isCollapsed) {
-      redux.uncollapse(props.node.id);
+      dispatch({ type: "UNCOLLAPSE", id: props.node.id });
     } else {
-      redux.collapse(props.node.id);
+      dispatch({ type: "COLLAPSE", id: props.node.id });
     }
   };
 

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -93,6 +93,7 @@ const Node = (
   };
 
   const keydownEnv: InputEnv = {
+    isNodeEnv: true,
     node: props.node,
 
     isLocked,

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -14,7 +14,7 @@ import CodeMirror from "codemirror";
 import { GetProps, useDrag, useDrop } from "react-dnd";
 import { RootState } from "../reducers";
 import { isDummyPos } from "../utils";
-import { defaultKeyMap, InputEnv, keyDown } from "../keymap";
+import { InputEnv, keyDown } from "../keymap";
 
 // TODO(Oak): make sure that all use of node.<something> is valid
 // since it might be cached and outdated
@@ -244,7 +244,7 @@ const Node = (
         onDragStart={handleMouseDragRelated}
         onDragEnd={handleMouseDragRelated}
         onDrop={handleMouseDragRelated}
-        onKeyDown={(e) => keyDown(e, keydownEnv, defaultKeyMap)}
+        onKeyDown={(e) => keyDown(e, keydownEnv)}
       >
         {props.children}
         {comment && comment.reactElement()}

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -14,7 +14,7 @@ import CodeMirror from "codemirror";
 import { GetProps, useDrag, useDrop } from "react-dnd";
 import { RootState } from "../reducers";
 import { isDummyPos } from "../utils";
-import { InputEnv } from "../keymap";
+import { defaultKeyMap, InputEnv, keyDown } from "../keymap";
 
 // TODO(Oak): make sure that all use of node.<something> is valid
 // since it might be cached and outdated
@@ -244,7 +244,7 @@ const Node = (
         onDragStart={handleMouseDragRelated}
         onDragEnd={handleMouseDragRelated}
         onDrop={handleMouseDragRelated}
-        onKeyDown={(e) => store.onKeyDown(e, keydownEnv)}
+        onKeyDown={(e) => keyDown(e, keydownEnv, defaultKeyMap)}
       >
         {props.children}
         {comment && comment.reactElement()}

--- a/src/keymap.tsx
+++ b/src/keymap.tsx
@@ -529,7 +529,7 @@ export const commandMap: {
   Help: function (_) {
     KeyDownContext.showDialog({
       title: "Keyboard Shortcuts",
-      content: renderKeyMap(defaultKeyMap),
+      content: <KeyMapTable keyMap={defaultKeyMap} />,
     });
   },
 };
@@ -581,7 +581,8 @@ export function keyDown(
   }
 }
 
-export function renderKeyMap(keyMap: { [index: string]: string }) {
+const KeyMapTable = (props: { keyMap: KeyMap }) => {
+  const { keyMap } = props;
   const reverseMap: { [index: string]: string[] } = {};
   Object.keys(keyMap).forEach((key) => {
     if (!reverseMap[keyMap[key]]) {
@@ -613,4 +614,4 @@ export function renderKeyMap(keyMap: { [index: string]: string }) {
       </tbody>
     </table>
   );
-}
+};

--- a/src/keymap.tsx
+++ b/src/keymap.tsx
@@ -538,12 +538,8 @@ export const commandMap: {
 // editor's keyMap. If there is a handler for that event, flatten the
 // environment and add some utility methods, then set the key handler's
 // "this" object to be that environment and call it.
-export function keyDown(
-  e: React.KeyboardEvent,
-  env: InputEnv,
-  keyMap: { [index: string]: string }
-) {
-  var handler = commandMap[keyMap[CodeMirror.keyName(e)]];
+export function keyDown(e: React.KeyboardEvent, env: InputEnv) {
+  var handler = commandMap[defaultKeyMap[CodeMirror.keyName(e)]];
   if (handler) {
     e.stopPropagation();
     env.props.dispatch((_, getState) => {

--- a/src/keymap.tsx
+++ b/src/keymap.tsx
@@ -26,8 +26,8 @@ import { findAdjacentDropTargetId as getDTid } from "./components/DropTarget";
 import type { AppDispatch } from "./store";
 import type { AST, ASTNode } from "./ast";
 import type { RootState } from "./reducers";
-import type { EnhancedNodeProps } from "./components/Node";
 import type { BlockEditorProps } from "./ui/BlockEditor";
+import { KeyDownContext } from "./ui/ToggleEditor";
 
 /**
  * This is completely bananas. This InputEnv type is what
@@ -46,7 +46,6 @@ import type { BlockEditorProps } from "./ui/BlockEditor";
  */
 export type InputEnv = {
   // added by BlockEditor before calling keyDown()
-  showDialog?: BlockEditorProps["showDialog"];
   toolbarRef?: BlockEditorProps["toolbarRef"];
 
   // defined by Node react component
@@ -531,7 +530,7 @@ export const commandMap: {
   },
 
   Help: function (_) {
-    this.showDialog({
+    KeyDownContext.showDialog({
       title: "Keyboard Shortcuts",
       content: renderKeyMap(defaultKeyMap),
     });

--- a/src/keymap.tsx
+++ b/src/keymap.tsx
@@ -169,7 +169,7 @@ Object.assign(defaultKeyMap, mac ? macKeyMap : pcKeyMap);
 // see https://codemirror.net/doc/manual.html#keymaps
 CodeMirror.normalizeKeyMap(defaultKeyMap);
 
-function pasteHandler(this: void, env: Env, _: Editor, e: React.KeyboardEvent) {
+const pasteHandler = (env: Env, e: React.KeyboardEvent) => {
   if (!env.isNodeEnv) {
     return CodeMirror.Pass;
   }
@@ -196,22 +196,17 @@ function pasteHandler(this: void, env: Env, _: Editor, e: React.KeyboardEvent) {
       say(`Cannot paste ${e.shiftKey ? "before" : "after"} this node.`);
     }
   }
-}
+};
 
 const commandMap: {
-  [index: string]: (
-    this: void,
-    env: Env,
-    cm: Editor,
-    e: React.KeyboardEvent
-  ) => void;
+  [index: string]: (env: Env, e: React.KeyboardEvent) => void;
 } = {
-  "Shift Focus": function (env, _, e) {
+  "Shift Focus": (env, e) => {
     e.preventDefault();
     KeyDownContext.toolbarRef.current.focus();
   },
   // NAVIGATION
-  "Previous Block": function (env, _, e) {
+  "Previous Block": (env, e) => {
     e.preventDefault();
     if (env.isNodeEnv) {
       let prev = env.fastSkip((node) => node.prev);
@@ -228,7 +223,7 @@ const commandMap: {
       : playSound(BEEP);
   },
 
-  "Next Block": function (env, _, e) {
+  "Next Block": (env, e) => {
     e.preventDefault();
     if (env.isNodeEnv) {
       let next = env.fastSkip((node) => node.next);
@@ -245,14 +240,14 @@ const commandMap: {
       : playSound(BEEP);
   },
 
-  "First Block": function (env, _) {
+  "First Block": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
     env.activateByNid(0, { allowMove: true });
   },
 
-  "Last Visible Block": function (env, _) {
+  "Last Visible Block": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     } else {
@@ -260,7 +255,7 @@ const commandMap: {
     }
   },
 
-  "Collapse or Focus Parent": function (env, _, e) {
+  "Collapse or Focus Parent": (env, e) => {
     e.preventDefault();
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
@@ -274,7 +269,7 @@ const commandMap: {
     }
   },
 
-  "Expand or Focus 1st Child": function (env, _, e) {
+  "Expand or Focus 1st Child": (env, e) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -289,7 +284,7 @@ const commandMap: {
     }
   },
 
-  "Collapse All": function (env, _) {
+  "Collapse All": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -297,7 +292,7 @@ const commandMap: {
     env.activateByNid(getRoot(env.node).nid);
   },
 
-  "Expand All": function (env, _) {
+  "Expand All": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     } else {
@@ -305,7 +300,7 @@ const commandMap: {
     }
   },
 
-  "Collapse Current Root": function (env, _) {
+  "Collapse Current Root": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -319,7 +314,7 @@ const commandMap: {
     }
   },
 
-  "Expand Current Root": function (env, _) {
+  "Expand Current Root": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -330,7 +325,7 @@ const commandMap: {
     env.activateByNid(root.nid);
   },
 
-  "Jump to Root": function (env, _) {
+  "Jump to Root": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     } else {
@@ -338,7 +333,7 @@ const commandMap: {
     }
   },
 
-  "Read Ancestors": function (env, _) {
+  "Read Ancestors": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -355,7 +350,7 @@ const commandMap: {
     }
   },
 
-  "Read Children": function (env, _) {
+  "Read Children": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     } else {
@@ -364,7 +359,7 @@ const commandMap: {
   },
 
   // SEARCH, SELECTION & CLIPBOARD
-  "Toggle Selection": function (env, _, e) {
+  "Toggle Selection": (env, e) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -417,7 +412,7 @@ const commandMap: {
     }
   },
 
-  Edit: function (env, _, e) {
+  Edit: (env, e) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -431,7 +426,7 @@ const commandMap: {
     }
   },
 
-  "Edit Anything": function (env, _, e) {
+  "Edit Anything": (env, e) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     } else {
@@ -439,14 +434,14 @@ const commandMap: {
     }
   },
 
-  "Clear Selection": function (env, _) {
+  "Clear Selection": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
     env.dispatch({ type: "SET_SELECTIONS", selections: [] });
   },
 
-  "Delete Nodes": function (env, _) {
+  "Delete Nodes": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -459,7 +454,7 @@ const commandMap: {
 
   // use the srcRange() to insert before/after the node *and*
   // any associated comments
-  "Insert Right": function (env, _) {
+  "Insert Right": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -467,7 +462,7 @@ const commandMap: {
       env.setCursor(env.node.srcRange().to);
     }
   },
-  "Insert Left": function (env, _) {
+  "Insert Left": (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -476,7 +471,7 @@ const commandMap: {
     }
   },
 
-  Cut: function (env, _) {
+  Cut: (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -488,7 +483,7 @@ const commandMap: {
     delete_(nodesToCut);
   },
 
-  Copy: function (env, _) {
+  Copy: (env, _) => {
     if (!env.isNodeEnv) {
       return CodeMirror.Pass;
     }
@@ -503,7 +498,7 @@ const commandMap: {
   Paste: pasteHandler,
   "Paste Before": pasteHandler,
 
-  "Activate Search Dialog": function (env, _) {
+  "Activate Search Dialog": (env, _) => {
     SHARED.search.onSearch(
       env.state,
       () => {},
@@ -511,29 +506,29 @@ const commandMap: {
     );
   },
 
-  "Search Previous": function (env, _, e) {
+  "Search Previous": (env, e) => {
     e.preventDefault();
     env.activateNoRecord(SHARED.search.search(false, env.state));
   },
 
-  "Search Next": function (env, _, e) {
+  "Search Next": (env, e) => {
     e.preventDefault();
     env.activateNoRecord(SHARED.search.search(true, env.state));
   },
 
-  Undo: function (env, _, e) {
+  Undo: (env, e) => {
     e.preventDefault();
     preambleUndoRedo("undo");
     SHARED.cm.undo();
   },
 
-  Redo: function (env, _, e) {
+  Redo: (env, e) => {
     e.preventDefault();
     preambleUndoRedo("redo");
     SHARED.cm.redo();
   },
 
-  Help: function (env, _) {
+  Help: (env, _) => {
     KeyDownContext.showDialog({
       title: "Keyboard Shortcuts",
       content: <KeyMapTable keyMap={defaultKeyMap} />,
@@ -582,7 +577,7 @@ export function keyDown(e: React.KeyboardEvent, inputEnv: InputEnv) {
         const updatedNode = state.ast.getNodeById(env.node.id);
         env.node = updatedNode && state.ast.getNodeByNId(updatedNode.nid);
       }
-      handler(env, SHARED.cm, e);
+      handler(env, e);
     });
   }
 }

--- a/src/keymap.tsx
+++ b/src/keymap.tsx
@@ -45,9 +45,6 @@ import { KeyDownContext } from "./ui/ToggleEditor";
  * abusive to the properties of the Node component.
  */
 export type InputEnv = {
-  // added by BlockEditor before calling keyDown()
-  toolbarRef?: BlockEditorProps["toolbarRef"];
-
   // defined by Node react component
   isLocked?(): boolean;
   handleMakeEditable?: (e?: React.KeyboardEvent) => void;
@@ -217,7 +214,7 @@ export const commandMap: {
 } = {
   "Shift Focus": function (_, e) {
     e.preventDefault();
-    this.toolbarRef.current.focus();
+    KeyDownContext.toolbarRef.current.focus();
   },
   // NAVIGATION
   "Previous Block": function (_, e) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,7 +2,6 @@ import { createStore, applyMiddleware } from "redux";
 import thunk, { ThunkDispatch, ThunkMiddleware } from "redux-thunk";
 import { reducer } from "./reducers";
 import type { RootState, AppAction } from "./reducers";
-import { InputEnv } from "./keymap";
 
 const reduxStore = createStore(
   reducer,
@@ -10,13 +9,7 @@ const reduxStore = createStore(
   applyMiddleware(thunk as ThunkMiddleware<RootState, AppAction>)
 );
 
-export type AppStore = typeof reduxStore & {
-  // TODO(pcardune): this onKeyDown property gets set by
-  // BlockEditor and used by the Node component for no apparent
-  // reason. It's effectively a global variable and should be
-  // stored somewhere else.
-  onKeyDown?: (e: React.KeyboardEvent, env: InputEnv) => void;
-};
+export type AppStore = typeof reduxStore;
 
 export const store: AppStore = reduxStore;
 

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -23,13 +23,11 @@ import {
 import type { afterDOMUpdateHandle } from "../utils";
 import BlockComponent from "../components/BlockComponent";
 import { defaultKeyMap, keyDown } from "../keymap";
-import { AppStore, store } from "../store";
 import { ASTNode, Pos } from "../ast";
 import type { AST } from "../ast";
 import CodeMirror, { Editor, SelectionOptions } from "codemirror";
 import type { Options, API } from "../CodeMirrorBlocks";
 import type { AppDispatch } from "../store";
-import Toolbar from "./Toolbar";
 import type { Activity, AppAction, Quarantine, RootState } from "../reducers";
 import type { IUnControlledCodeMirror } from "react-codemirror2";
 
@@ -285,13 +283,11 @@ export type BlockEditorProps = typeof BlockEditor.defaultProps &
     value: string;
     options?: Options;
     cmOptions?: CodeMirror.EditorConfiguration;
-    keyMap?: { [index: string]: string };
     /**
      * id of the language being used
      */
     languageId: string;
     search?: Search;
-    toolbarRef?: React.RefObject<HTMLInputElement>;
     onBeforeChange?: IUnControlledCodeMirror["onBeforeChange"];
     onMount: Function;
     api?: API;
@@ -308,24 +304,12 @@ class BlockEditor extends Component<BlockEditorProps> {
     super(props);
     this.mouseUsed = false;
 
-    /**
-     * @internal
-     * When the CM instance receives a keydown event...construct the environment
-     * NOTE: This is called from both CM *and* Node components. Each is responsible
-     * for passing 'this' as the environment. Be sure to add showDialog and toolbarRef!
-     */
-    store.onKeyDown = (e, env) => {
-      env.toolbarRef = this.props.toolbarRef;
-      return keyDown(e, env, this.props.keyMap);
-    };
-
     // NOTE(Emmanuel): we shouldn't have to dispatch this in the constructor
     // just for tests to pass! Figure out how to reset the store manually
     props.dispatch({ type: "RESET_STORE_FOR_TESTING" });
   }
 
   static defaultProps = {
-    keyMap: defaultKeyMap,
     search: {
       search: () => null,
       onSearch: () => {},
@@ -906,7 +890,7 @@ class BlockEditor extends Component<BlockEditorProps> {
           onMouseDown={this.handleTopLevelMouseDown}
           onFocus={this.handleTopLevelFocus}
           onPaste={this.handleTopLevelPaste}
-          onKeyDown={(_, e) => store.onKeyDown(e, this)}
+          onKeyDown={(_, e) => keyDown(e, this, defaultKeyMap)}
           onCursorActivity={this.handleTopLevelCursorActivity}
           editorDidMount={this.handleEditorDidMount}
         />

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -22,7 +22,7 @@ import {
 } from "../utils";
 import type { afterDOMUpdateHandle } from "../utils";
 import BlockComponent from "../components/BlockComponent";
-import { keyDown } from "../keymap";
+import { InputEnv, keyDown } from "../keymap";
 import { ASTNode, Pos } from "../ast";
 import type { AST } from "../ast";
 import CodeMirror, { Editor, SelectionOptions } from "codemirror";
@@ -879,6 +879,15 @@ class BlockEditor extends Component<BlockEditorProps> {
     if (this.props.languageId) {
       classes.push(`blocks-language-${this.props.languageId}`);
     }
+
+    const keyDownEnv: InputEnv = {
+      props: {
+        dispatch: this.props.dispatch,
+        activateByNid: this.props.activateByNid,
+        setCursor: this.props.setCursor,
+      },
+    };
+
     return (
       <>
         <DragAndDropEditor
@@ -890,7 +899,7 @@ class BlockEditor extends Component<BlockEditorProps> {
           onMouseDown={this.handleTopLevelMouseDown}
           onFocus={this.handleTopLevelFocus}
           onPaste={this.handleTopLevelPaste}
-          onKeyDown={(_, e) => keyDown(e, this)}
+          onKeyDown={(_, e) => keyDown(e, keyDownEnv)}
           onCursorActivity={this.handleTopLevelCursorActivity}
           editorDidMount={this.handleEditorDidMount}
         />

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -881,11 +881,9 @@ class BlockEditor extends Component<BlockEditorProps> {
     }
 
     const keyDownEnv: InputEnv = {
-      props: {
-        dispatch: this.props.dispatch,
-        activateByNid: this.props.activateByNid,
-        setCursor: this.props.setCursor,
-      },
+      dispatch: this.props.dispatch,
+      activateByNid: this.props.activateByNid,
+      setCursor: this.props.setCursor,
     };
 
     return (

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -881,6 +881,7 @@ class BlockEditor extends Component<BlockEditorProps> {
     }
 
     const keyDownEnv: InputEnv = {
+      isNodeEnv: false,
       dispatch: this.props.dispatch,
       activateByNid: this.props.activateByNid,
       setCursor: this.props.setCursor,

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -22,7 +22,7 @@ import {
 } from "../utils";
 import type { afterDOMUpdateHandle } from "../utils";
 import BlockComponent from "../components/BlockComponent";
-import { defaultKeyMap, keyDown } from "../keymap";
+import { keyDown } from "../keymap";
 import { ASTNode, Pos } from "../ast";
 import type { AST } from "../ast";
 import CodeMirror, { Editor, SelectionOptions } from "codemirror";
@@ -890,7 +890,7 @@ class BlockEditor extends Component<BlockEditorProps> {
           onMouseDown={this.handleTopLevelMouseDown}
           onFocus={this.handleTopLevelFocus}
           onPaste={this.handleTopLevelPaste}
-          onKeyDown={(_, e) => keyDown(e, this, defaultKeyMap)}
+          onKeyDown={(_, e) => keyDown(e, this)}
           onCursorActivity={this.handleTopLevelCursorActivity}
           editorDidMount={this.handleEditorDidMount}
         />

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -883,8 +883,6 @@ class BlockEditor extends Component<BlockEditorProps> {
     const keyDownEnv: InputEnv = {
       isNodeEnv: false,
       dispatch: this.props.dispatch,
-      activateByNid: this.props.activateByNid,
-      setCursor: this.props.setCursor,
     };
 
     return (

--- a/src/ui/ToggleEditor.tsx
+++ b/src/ui/ToggleEditor.tsx
@@ -328,6 +328,8 @@ export const KeyDownContext = {
   showDialog: (contents: ToggleEditorState["dialog"]) => {
     console.warn(`ToggleEditor has not been mounted yet. Can't show dialog`);
   },
+
+  toolbarRef: createRef<HTMLInputElement>(),
 };
 
 class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
@@ -348,7 +350,6 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
   cmOptions: CodeMirror.EditorConfiguration;
   options: Options;
   eventHandlers: Record<string, Function[]>;
-  toolbarRef: React.RefObject<HTMLInputElement> = createRef();
   ast?: AST;
   newAST?: AST;
 
@@ -592,7 +593,7 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
               }
               languageId={this.props.language.id}
               blockMode={this.state.blockMode}
-              toolbarRef={this.toolbarRef}
+              toolbarRef={KeyDownContext.toolbarRef}
             />
           </div>
           <div className="col-xs-9 codemirror-pane">
@@ -648,7 +649,6 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
         appElement={this.props.appElement}
         languageId={this.props.language.id}
         options={{ ...defaultOptions, ...this.props.options }}
-        toolbarRef={this.toolbarRef}
       />
     );
   }


### PR DESCRIPTION
1. Node.tsx and BlockEditor.tsx now call `keyDown()` directly instead of it being routed through `store.onKeyDown`.
2. keydown handlers do not use `this` anymore, and instead take a typesafe env object.
3. BlockEditor.tsx only passes what keyDown actually needs, and not its whole instance
4. The keydown env object is not longer a bunch of component props, dispatch wrappers, and random functions mashed together into a single object.
5. A few bugs were found and fixed:
   - using arrow keys on the node preview after selecting something in the toolbar would spew errors in the log. now it just beeps.
   - up and down arrow keys when not focused on a node spewed errors and didn't do anything. Now they work.

It seems like someone was trying to (or preparing to) do something much more complicated than what the current feature set supports. Were there some more complicated features planned that never got implemented? Like language specific keyboard navigation hooks or something? If not, this could be simplified a lot further.