### PR TITLE
cancel all outstanding dom updates in teardown

### DIFF
--- a/spec/activation-test.ts
+++ b/spec/activation-test.ts
@@ -27,28 +27,26 @@ describe("when dealing with node activation,", () => {
   beforeEach(async () => {
     cmb = await mountCMB(wescheme);
     cmb.setValue("11\n54");
-    await finishRender(cmb);
+    await finishRender();
     let ast = cmb.getAst();
     literal1 = ast.rootNodes[0];
     literal2 = ast.rootNodes[1];
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   it("should only allow one node to be active at a time", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     mouseDown(literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).not.toBe(literal1);
     expect(cmb.getFocusedNode()).toBe(literal2);
   });
 
   it("should put focus on the active node", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(document.activeElement).toBe(literal1.element);
     expect(activeAriaId(cmb)).toBe(literal1.element.id);
   });
@@ -56,20 +54,20 @@ describe("when dealing with node activation,", () => {
   it("should not delete active nodes when the delete key is pressed", async () => {
     expect(cmb.getValue()).toBe("11\n54");
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(literal1);
 
     keyDown("Delete");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toBe("11\n54");
   });
 
   it("should activate the first node when down is pressed", async () => {
     mouseDown(literal1.element);
     keyDown("[", { ctrlKey: true }, literal1.element); // set cursor to the left
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(literal1);
     expect(cmb.getScrollerElement().getAttribute("aria-activedescendent")).toBe(
       "block-node-" + literal1.id
@@ -79,7 +77,7 @@ describe("when dealing with node activation,", () => {
   it("should activate the next node when down is pressed", async () => {
     keyDown("ArrowDown");
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).not.toBe(literal1);
     expect(cmb.getFocusedNode()).toBe(literal2);
     expect(activeAriaId(cmb)).toBe(literal2.element.id);
@@ -88,7 +86,7 @@ describe("when dealing with node activation,", () => {
   it("should activate the node after the cursor when down is pressed", async () => {
     cmb.setCursor({ line: 0, ch: 2 });
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).not.toBe(literal1);
     expect(cmb.getFocusedNode()).toBe(literal2);
     expect(activeAriaId(cmb)).toBe(literal2.element.id);
@@ -97,7 +95,7 @@ describe("when dealing with node activation,", () => {
   it("should activate the node before the cursor when up is pressed", async () => {
     cmb.setCursor({ line: 0, ch: 2 });
     keyDown("ArrowUp");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).not.toBe(literal2);
     expect(cmb.getFocusedNode()).toBe(literal1);
     expect(activeAriaId(cmb)).toBe(literal1.element.id);
@@ -105,43 +103,43 @@ describe("when dealing with node activation,", () => {
 
   it("should toggle the editability of activated node when Enter is pressed", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(literal1);
     expect(literal1.isEditable()).toBe(false);
 
     keyDown("Enter");
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.isEditable()).toBe(true);
   });
 
   it("should cancel the editability of activated node when Esc is pressed", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(literal1);
 
     keyDown("Enter");
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.isEditable()).toBe(true);
     insertText("sugarPlums");
 
     keyDown("Escape");
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.isEditable()).toBe(false);
     expect(cmb.getValue()).toBe("11\n54");
   });
 
   it("should cancel the editability of activated node when Alt-Q is pressed", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(literal1);
 
     keyDown("Enter");
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.isEditable()).toBe(true);
     insertText("sugarPlums");
 
     keyDown("Q", { altKey: true });
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.isEditable()).toBe(false);
     expect(cmb.getValue()).toBe("11\n54");
   });
@@ -156,24 +154,22 @@ describe("cut/copy/paste", () => {
     cmb = await mountCMB(wescheme);
 
     cmb.setValue("11\n54");
-    await finishRender(cmb);
+    await finishRender();
     let ast = cmb.getAst();
     literal1 = ast.rootNodes[0];
     literal2 = ast.rootNodes[1];
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   it("should remove selected nodes on cut", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
 
     keyDown("X", cmd_ctrl, literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toBe("\n54");
     expect(cmb.getFocusedNode().id).toBe(literal2.id);
     expect(cmb.getFocusedNode().hash).toBe(literal2.hash);
@@ -182,14 +178,14 @@ describe("cut/copy/paste", () => {
   it("should remove multiple selected nodes on cut", async () => {
     mouseDown(literal1);
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowDown");
     keyDown(" ", {}, literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(2);
 
     keyDown("X", cmd_ctrl, literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(0);
     expect(cmb.getValue()).toBe("\n");
     expect(cmb.getFocusedNode()).toBe(undefined);
@@ -222,28 +218,26 @@ describe("tree navigation", () => {
     thirdArg = firstRoot.args[2];
     nestedExpr = thirdRoot.args[1] as FunctionApp;
     lastNode = nestedExpr.args[1];
-    await finishRender(cmb);
+    await finishRender();
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   it("up-arrow should navigate to the previous visible node, but not beyond the tree", async () => {
     mouseDown(firstRoot);
     keyDown("ArrowLeft", {}, firstRoot); // collapse that root
     mouseDown(secondRoot);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(secondRoot);
     expect(activeAriaId(cmb)).toBe(secondRoot.element.id);
 
     keyDown("ArrowUp");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(firstRoot);
     expect(activeAriaId(cmb)).toBe(firstRoot.element.id);
 
     keyDown("ArrowUp");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(firstRoot);
     expect(activeAriaId(cmb)).toBe(firstRoot.element.id);
   });
@@ -252,16 +246,16 @@ describe("tree navigation", () => {
     mouseDown(firstRoot);
     keyDown("ArrowLeft", {}, firstRoot); // collapse that root
     mouseDown(nestedExpr.args[0]);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(nestedExpr.args[0]);
 
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(nestedExpr.args[1]);
     expect(activeAriaId(cmb)).toBe(nestedExpr.args[1].element.id);
 
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(nestedExpr.args[1]);
     expect(activeAriaId(cmb)).toBe(nestedExpr.args[1].element.id);
   });
@@ -271,19 +265,19 @@ describe("tree navigation", () => {
     keyDown("ArrowLeft", {}, firstRoot); // collapse that root
     mouseDown(firstRoot);
     keyDown("ArrowLeft", {}, firstRoot); // collapse that root *again*
-    await finishRender(cmb);
+    await finishRender();
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("false");
 
     mouseDown(secondRoot);
     keyDown("ArrowLeft", {}, secondRoot); // collapse that root
-    await finishRender(cmb);
+    await finishRender();
     expect(secondRoot.element.getAttribute("aria-expanded")).toBe(null);
   });
 
   it("shift-left-arrow should collapse all blocks", async () => {
     mouseDown(firstRoot);
     keyDown("ArrowLeft", { shiftKey: true }, firstRoot);
-    await finishRender(cmb);
+    await finishRender();
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("false");
     expect(secondRoot.element.getAttribute("aria-expanded")).toBe(null);
     expect(thirdRoot.element.getAttribute("aria-expanded")).toBe("false");
@@ -293,7 +287,7 @@ describe("tree navigation", () => {
   it("shift-right-arrow should expand all blocks", async () => {
     mouseDown(firstRoot);
     keyDown("ArrowLeft", { shiftKey: true }, firstRoot);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowRight", { shiftKey: true }, firstRoot);
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("true");
     expect(secondRoot.element.getAttribute("aria-expanded")).toBe(null);
@@ -304,7 +298,7 @@ describe("tree navigation", () => {
   it("shift-alt-left-arrow should collapse only the currently-active root", async () => {
     mouseDown(lastNode);
     keyDown("ArrowLeft", { shiftKey: true }, firstRoot); // collapse all
-    await finishRender(cmb);
+    await finishRender();
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("false");
     expect(secondRoot.element.getAttribute("aria-expanded")).toBe(null);
     expect(thirdRoot.element.getAttribute("aria-expanded")).toBe("false");
@@ -318,7 +312,7 @@ describe("tree navigation", () => {
 
   it("shift-alt-right-arrow should expand only the currently-active root", async () => {
     mouseDown(lastNode);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowLeft", { shiftKey: true, altKey: true }, lastNode);
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("true");
     expect(secondRoot.element.getAttribute("aria-expanded")).toBe(null);
@@ -329,7 +323,7 @@ describe("tree navigation", () => {
   it("less-than should activate root without collapsing", async () => {
     mouseDown(nestedExpr.args[1]);
     keyDown("<", { shiftKey: true }, nestedExpr.args[1]);
-    await finishRender(cmb);
+    await finishRender();
     expect(thirdRoot.element.getAttribute("aria-expanded")).toBe("true");
     expect(cmb.getFocusedNode()).toBe(thirdRoot);
   });
@@ -337,16 +331,16 @@ describe("tree navigation", () => {
   it("right-arrow should expand a block, or shift focus to 1st child", async () => {
     mouseDown(firstRoot);
     keyDown("ArrowLeft", {}, firstRoot);
-    await finishRender(cmb);
+    await finishRender();
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("false");
 
     keyDown("ArrowRight");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(firstRoot);
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("true");
 
     keyDown("ArrowRight");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(funcSymbol);
     expect(firstRoot.element.getAttribute("aria-expanded")).toBe("true");
   });
@@ -354,10 +348,10 @@ describe("tree navigation", () => {
   it("home should activate the first visible node", async () => {
     mouseDown(firstRoot);
     keyDown("ArrowLeft", {}, firstRoot);
-    await finishRender(cmb);
+    await finishRender();
     mouseDown(secondRoot);
     keyDown("Home");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(firstRoot);
     expect(activeAriaId(cmb)).toBe(firstRoot.element.id);
   });
@@ -365,17 +359,17 @@ describe("tree navigation", () => {
   // TODO: this test legitimately fails
   it("end should activate the last visible node", async () => {
     mouseDown(secondRoot);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("End");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(lastNode);
     expect(activeAriaId(cmb)).toBe(lastNode.element.id);
     mouseDown(nestedExpr);
     keyDown("ArrowLeft", {}, nestedExpr);
-    await finishRender(cmb);
+    await finishRender();
     mouseDown(secondRoot);
     keyDown("End");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getFocusedNode()).toBe(nestedExpr);
     expect(activeAriaId(cmb)).toBe(nestedExpr.element.id);
   });
@@ -394,22 +388,20 @@ describe("when dealing with node selection, ", () => {
     literal1 = ast.rootNodes[0];
     literal2 = ast.rootNodes[1];
     expr = ast.rootNodes[2] as FunctionApp;
-    await finishRender(cmb);
+    await finishRender();
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   it("space key toggles selection on and off", async () => {
     mouseDown(literal1);
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.element.getAttribute("aria-selected")).toBe("true");
     expect(cmb.getSelectedNodes().length).toBe(1);
 
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.element.getAttribute("aria-selected")).toBe("false");
     expect(cmb.getSelectedNodes().length).toBe(0);
   });
@@ -417,41 +409,41 @@ describe("when dealing with node selection, ", () => {
   it("esc key clears selection", async () => {
     mouseDown(literal1);
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.element.getAttribute("aria-selected")).toBe("true");
     expect(cmb.getSelectedNodes().length).toBe(1);
     mouseDown(literal2);
     keyDown(" ", {}, literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(literal2.element.getAttribute("aria-selected")).toBe("true");
     expect(cmb.getSelectedNodes().length).toBe(2);
     keyDown("Escape", {}, literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(0);
   });
 
   it("Alt-Q key clears selection", async () => {
     mouseDown(literal1);
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.element.getAttribute("aria-selected")).toBe("true");
     expect(cmb.getSelectedNodes().length).toBe(1);
     mouseDown(literal2);
     keyDown(" ", {}, literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(literal2.element.getAttribute("aria-selected")).toBe("true");
     expect(cmb.getSelectedNodes().length).toBe(2);
     keyDown("Q", { altKey: true }, literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(0);
   });
 
   it("arrow preserves selection & changes active ", async () => {
     mouseDown(literal1);
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.element.getAttribute("aria-selected")).toBe("true");
     expect(literal2.element.getAttribute("aria-selected")).toBe("false");
     expect(cmb.getFocusedNode()).toBe(literal2);
@@ -461,13 +453,13 @@ describe("when dealing with node selection, ", () => {
   it("allow multiple, non-contiguous selection ", async () => {
     mouseDown(literal1);
     keyDown(" ", {}, literal1);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowDown"); // skip over literal2
-    await finishRender(cmb);
+    await finishRender();
     keyDown(" ", {}, expr);
-    await finishRender(cmb);
+    await finishRender();
     expect(literal1.element.getAttribute("aria-selected")).toBe("true");
     expect(literal2.element.getAttribute("aria-selected")).toBe("false");
     expect(expr.element.getAttribute("aria-selected")).toBe("true");
@@ -478,11 +470,11 @@ describe("when dealing with node selection, ", () => {
   it("selecting a parent, then deselecting a child should deselect the parent ", async () => {
     mouseDown(expr);
     keyDown(" ", {}, expr);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowDown");
-    await finishRender(cmb);
+    await finishRender();
     keyDown(" ", {}, expr.func);
-    await finishRender(cmb);
+    await finishRender();
     expect(expr.element.getAttribute("aria-selected")).toBe("false");
     expect(expr.func.element.getAttribute("aria-selected")).toBe("false");
     expect(expr.args[0].element.getAttribute("aria-selected")).toBe("true");
@@ -495,11 +487,11 @@ describe("when dealing with node selection, ", () => {
   it("selecting a child, then parent should select all children as well ", async () => {
     mouseDown(expr.func);
     keyDown(" ", {}, expr.func);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("ArrowUp");
-    await finishRender(cmb);
+    await finishRender();
     keyDown(" ", {}, expr);
-    await finishRender(cmb);
+    await finishRender();
     expect(expr.element.getAttribute("aria-selected")).toBe("true");
     expect(expr.func.element.getAttribute("aria-selected")).toBe("true");
     expect(cmb.getFocusedNode()).toBe(expr);

--- a/spec/api-test.ts
+++ b/spec/api-test.ts
@@ -32,18 +32,16 @@ describe("when testing CM apis,", () => {
   beforeEach(async () => {
     cmb = await mountCMB(wescheme);
     cmb.setBlockMode(false);
-    await finishRender(cmb);
+    await finishRender();
     cmb.setValue(`(+ 1 2)\ny`);
-    await finishRender(cmb);
+    await finishRender();
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   it("those unsupported in the BlockEditor should throw errors", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     expect(() => cmb.cursorCoords(true, "page")).toThrow();
     expect(() => cmb.addKeyMap("foo")).toThrow();
     expect(() => cmb.addOverlay(true)).toThrow();
@@ -136,7 +134,7 @@ describe("when testing CM apis,", () => {
     expect(() => cmb.setSize(lineNumber, 0)).not.toThrow();
     expect(() => cmb.undo()).not.toThrow();
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
 
     expect(() => cmb.setValue(code)).not.toThrow();
     expect(() => cmb.addLineClass(0, "text", className)).not.toThrow();
@@ -189,10 +187,10 @@ describe("when testing CM apis,", () => {
   });
 
   it("addSelection should work as-is for text mode", async () => {
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.listSelections().length).toBe(1);
     cmb.addSelection({ line: 0, ch: 0 }, { line: 0, ch: 7 });
-    await finishRender(cmb);
+    await finishRender();
     // strip out the first selection, build a simple from/to Object
     const r = cmb.listSelections()[0];
     const simpleRange = { from: r.anchor, to: r.head };
@@ -204,19 +202,19 @@ describe("when testing CM apis,", () => {
 
   it("addSelection should work as-expected for block mode", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.listSelections().length).toBe(1);
     cmb.addSelection({ line: 0, ch: 0 }, { line: 0, ch: 7 });
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.listSelections().length).toBe(2);
     const firstRoot = currentFirstRoot().element;
     expect(firstRoot.getAttribute("aria-selected")).toBe("true");
   });
 
   it("getCursor should work as-is for Text", async () => {
-    await finishRender(cmb);
+    await finishRender();
     cmb.setSelection({ line: 0, ch: 0 }, { line: 0, ch: 7 });
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getBlockMode()).toBe(false);
     expect(cmb.listSelections().length).toBe(1);
     expect(simpleCursor(cmb.getCursor())).toEqual({ line: 0, ch: 7 });
@@ -237,9 +235,9 @@ describe("when testing CM apis,", () => {
 
   it("getCursor should only work with head/to for Blocks", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     mouseDown(currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     expect(simpleCursor(cmb.getCursor())).toEqual({ line: 0, ch: 0 });
     expect(() => cmb.getCursor("head")).toThrow();
     expect(() => cmb.getCursor("anchor")).toThrow();
@@ -256,7 +254,7 @@ describe("when testing CM apis,", () => {
   it("getSelection should work as-expected for blocks selected programmatically", async () => {
     cmb.setValue(`(+ 1 2)\ny`);
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     cmb.setSelection({ line: 0, ch: 0 }, { line: 1, ch: 1 });
     expect(cmb.getSelection("MOO")).toBe("(+ 1 2)MOOy");
@@ -266,16 +264,16 @@ describe("when testing CM apis,", () => {
 
   it("getSelection should work as-expected for blocks", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     click(currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     keyDown(" ", {}, currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     const selectedNodes = cmb.getSelectedNodes();
     expect(selectedNodes.length).toBe(4);
     expect(cmb.getSelection("MOO")).toBe("(+ 1 2)MOO");
-    await finishRender(cmb);
+    await finishRender();
     expect(currentFirstRoot().element.getAttribute("aria-selected")).toBe(
       "true"
     );
@@ -290,7 +288,7 @@ describe("when testing CM apis,", () => {
 
   it("getSelections should work as-expected for blocks selected programmatically", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     cmb.setSelection({ line: 0, ch: 0 }, { line: 1, ch: 1 });
     expect(cmb.getSelections("MOO")).toEqual(["(+ 1 2)MOOy"]);
     cmb.setSelection({ line: 0, ch: 0 }, { line: 0, ch: 0 });
@@ -299,11 +297,11 @@ describe("when testing CM apis,", () => {
 
   it("getSelections should work as-expected for blocks using block selection", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     mouseDown(currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     keyDown(" ", {}, currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     const selectedNodes = cmb.getSelectedNodes();
     expect(selectedNodes.length).toBe(4);
     const selections = cmb.getSelections("MOO");
@@ -318,14 +316,14 @@ describe("when testing CM apis,", () => {
     // textmode API test
     cmb.focus();
     cmb.setCursor({ line: 0, ch: 0 });
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.hasFocus()).toBe(true);
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     cmb.focus();
     click(currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.hasFocus()).toBe(true);
   });
 
@@ -344,7 +342,7 @@ describe("when testing CM apis,", () => {
       { anchor: { line: 2, ch: 0 }, head: { line: 2, ch: 7 } },
     ]);
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     cmb.setSelections([
       { anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 7 } },
@@ -360,7 +358,7 @@ describe("when testing CM apis,", () => {
 
   it("replaceRange", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     expect(() =>
       cmb.replaceRange("Maya", { line: 0, ch: 2 }, { line: 0, ch: 7 })
@@ -373,7 +371,7 @@ describe("when testing CM apis,", () => {
 
   it("replaceSelection", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     expect(() =>
       cmb.replaceRange("Maya", { line: 0, ch: 2 }, { line: 0, ch: 7 })
@@ -387,14 +385,14 @@ describe("when testing CM apis,", () => {
   it("replaceSelections should work as-expected in blockmode", async () => {
     cmb.setValue("(+ 1 2)\nx\n(+ 3 4)");
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     keyDown(" ", {}, currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(4);
     mouseDown(currentThirdRoot());
     keyDown(" ", {}, currentThirdRoot());
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(8);
     cmb.replaceSelections(["Maya", "Schanzer"]);
     expect(cmb.getValue()).toBe("Maya\nx\nSchanzer");
@@ -402,9 +400,9 @@ describe("when testing CM apis,", () => {
 
   it("replaceSelections should work as-is in textmode", async () => {
     cmb.setBlockMode(false);
-    await finishRender(cmb);
+    await finishRender();
     cmb.setValue("(+ 1 2)\nx\n(+ 3 4)");
-    await finishRender(cmb);
+    await finishRender();
     // textmode API test
     cmb.setSelections([
       { anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 7 } },
@@ -417,12 +415,12 @@ describe("when testing CM apis,", () => {
   it("setBookmark", async () => {
     const domNode = document.createElement("span");
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     expect(() =>
       cmb.setBookmark({ line: 0, ch: 2 }, { widget: domNode })
     ).toThrow();
     cmb.setBlockMode(false);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.setBookmark({ line: 0, ch: 2 }, { widget: domNode })).not.toBe(
       null
     );
@@ -430,7 +428,7 @@ describe("when testing CM apis,", () => {
 
   it("setCursor should work as-is for text, or activate the containing block", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     cmb.setCursor({ line: 1, ch: 1 });
     expect(simpleCursor(cmb.getCursor())).toEqual({ line: 1, ch: 1 });
     expect(currentFocusNId()).toBe(0);
@@ -438,6 +436,7 @@ describe("when testing CM apis,", () => {
     expect(currentFocusNId()).toBe(0);
     // activating the first block should return a cursor at its end
     expect(simpleCursor(cmb.getCursor())).toEqual({ line: 0, ch: 7 });
+    await finishRender();
   });
 
   it("setSelection", async () => {
@@ -451,7 +450,7 @@ describe("when testing CM apis,", () => {
       { anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 7 } },
     ]);
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     expect(() =>
       cmb.setSelection({ line: 0, ch: 0 }, { line: 0, ch: 3 })
@@ -486,7 +485,7 @@ describe("when testing CM apis,", () => {
       { anchor: { line: 2, ch: 0 }, head: { line: 2, ch: 7 } },
     ]);
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     // blockmode API test
     expect(() =>
       cmb.setSelections([
@@ -508,24 +507,24 @@ describe("when testing CM apis,", () => {
 
   it("somethingSelected should work for selected blocks and text ranges", async () => {
     cmb.setBlockMode(true);
-    await finishRender(cmb);
+    await finishRender();
     const firstRoot = currentFirstRoot();
     expect(cmb.somethingSelected()).toBe(false);
     mouseDown(firstRoot);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(0);
     keyDown(" ", {}, firstRoot);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(4);
     expect(cmb.somethingSelected()).toBe(true);
     cmb.setSelection({ line: 0, ch: 0 }, { line: 0, ch: 0 });
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(0);
     expect(cmb.somethingSelected()).toBe(false);
     cmb.addSelection({ line: 0, ch: 0 }, { line: 0, ch: 7 });
     expect(cmb.somethingSelected()).toBe(true);
     cmb.setSelection({ line: 0, ch: 0 }, { line: 0, ch: 0 });
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(0);
     expect(cmb.somethingSelected()).toBe(false);
     cmb.addSelection({ line: 0, ch: 0 }, { line: 1, ch: 1 });

--- a/spec/comment-test.ts
+++ b/spec/comment-test.ts
@@ -59,7 +59,7 @@ describe("When editing and moving commented nodes", function () {
 #| comment2 |#
 2`);
       cmb.setBlockMode(true);
-      await finishRender(cmb);
+      await finishRender();
       let ast = cmb.getAst();
       expr0 = ast.rootNodes[0];
       expr1 = ast.rootNodes[1];
@@ -68,7 +68,7 @@ describe("When editing and moving commented nodes", function () {
 
     it("when the mode is toggled, it should reformat all comments as block comments", async function () {
       cmb.setBlockMode(false);
-      await finishRender(cmb);
+      await finishRender();
       // the opening whitespace should be removed!
       expect(cmb.getValue()).toBe(`(comment free)
 1 #| comment1 |#
@@ -84,7 +84,7 @@ describe("When editing and moving commented nodes", function () {
       );
       await wait(QUARANTINE_DELAY);
       click(expr0);
-      await finishRender(cmb);
+      await finishRender();
       expect(cmb.getValue()).toBe(`(comment free)
 1 #| comment1 |#
 #| comment2 |#
@@ -100,7 +100,7 @@ describe("When editing and moving commented nodes", function () {
       );
       await wait(QUARANTINE_DELAY);
       click(expr0);
-      await finishRender(cmb);
+      await finishRender();
       expect(cmb.getValue()).toBe(`(comment free)
 1 #| comment1 |#
 1 #| comment1 |#

--- a/spec/drag-test.ts
+++ b/spec/drag-test.ts
@@ -27,9 +27,7 @@ describe("Drag and drop", () => {
     cmb = await mountCMB(wescheme);
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   describe("when drag existing node and drop on existing node,", () => {
     let funcSymbol: ASTNode;
@@ -51,7 +49,7 @@ describe("Drag and drop", () => {
 
     beforeEach(async () => {
       cmb.setValue("(+ 1 2 3)");
-      await finishRender(cmb);
+      await finishRender();
       retrieve();
     });
 
@@ -182,7 +180,7 @@ describe("Drag and drop", () => {
     */
     it("save collapsed state when dragging root to be the last child of the next root", async () => {
       cmb.setValue("(collapse me)\n(+ 1 2)");
-      await finishRender(cmb);
+      await finishRender();
       let firstRoot: ASTNode;
       let lastDropTarget: Element;
       let retrieve = () => {
@@ -198,7 +196,7 @@ describe("Drag and drop", () => {
       let dragEvent = dragstart();
       firstRoot.element.dispatchEvent(dragEvent); // drag to the last droptarget
       lastDropTarget.dispatchEvent(drop());
-      await finishRender(cmb);
+      await finishRender();
       retrieve();
       let newFirstRoot = cmb.getAst().rootNodes[0] as FunctionApp;
       let newLastChild = newFirstRoot.args[2];
@@ -221,7 +219,7 @@ describe("Drag and drop", () => {
 
     beforeEach(async () => {
       cmb.setValue(";comment\n(a)\n(c)\n(define-struct e ())\ng");
-      await finishRender(cmb);
+      await finishRender();
       retrieve();
     });
 
@@ -233,14 +231,14 @@ describe("Drag and drop", () => {
       let dragEvent = dragstart();
       source.element.dispatchEvent(dragEvent); // drag to the last droptarget
       target1.dispatchEvent(drop());
-      await finishRender(cmb);
+      await finishRender();
     });
 
     it("regression test for empty identifierLists returning a null location", async () => {
       let dragEvent = dragstart();
       source.element.dispatchEvent(dragEvent); // drag to the last droptarget
       target2.dispatchEvent(drop());
-      await finishRender(cmb);
+      await finishRender();
     });
   });
 });

--- a/spec/focus-test.ts
+++ b/spec/focus-test.ts
@@ -28,7 +28,7 @@ describe("focusing,", () => {
   beforeEach(async () => {
     cmb = await mountCMB(wescheme);
     cmb.setValue("(+ 1 2 3)");
-    await finishRender(cmb);
+    await finishRender();
     expression = cmb.getAst().rootNodes[0] as FunctionApp;
     func = expression.func;
     literal1 = expression.args[0];
@@ -36,9 +36,7 @@ describe("focusing,", () => {
     literal3 = expression.args[2];
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   it("tabbing to the editor for the first time should activate node 0", async () => {
     cmb.focus();
@@ -47,59 +45,59 @@ describe("focusing,", () => {
 
   it("deleting the last node should shift focus to the next-to-last", async () => {
     mouseDown(literal3);
-    await finishRender(cmb);
+    await finishRender();
     expect(document.activeElement).toBe(literal3.element);
     keyDown(" ");
     keyDown("Delete");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toBe("(+ 1 2)");
     expect(cmb.getFocusedNode().id).toBe(literal2.id);
   });
 
   it("deleting the first node should shift focus to the parent", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     expect(document.activeElement).toBe(literal1.element);
     keyDown(" ");
     keyDown("Delete");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toBe("(+ 2 3)");
     expect(cmb.getFocusedNode().id).toBe(func.id);
   });
 
   it("deleting the nth node should shift focus to n-1", async () => {
     mouseDown(literal2);
-    await finishRender(cmb);
+    await finishRender();
     expect(document.activeElement).toBe(literal2.element);
     keyDown(" ");
     keyDown("Delete");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toBe("(+ 1 3)");
     expect(cmb.getFocusedNode().id).toBe(literal1.id);
   });
 
   it("deleting multiple nodes should shift focus to the one before", async () => {
     mouseDown(literal2);
-    await finishRender(cmb);
+    await finishRender();
     keyDown(" ");
     keyDown("ArrowDown");
     keyDown(" ", {}, literal3);
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getSelectedNodes().length).toBe(2);
     keyDown("Delete");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toBe("(+ 1)");
     expect(cmb.getFocusedNode().id).toBe(literal1.id);
   });
 
   it("inserting a node should put focus on the new node", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("]", { ctrlKey: true });
-    await finishRender(cmb);
+    await finishRender();
     insertText("99"); // in place of 2x keydown
     keyDown("Enter");
-    await finishRender(cmb);
+    await finishRender();
     // extra WS is removed when we switch back to text, but in blockmode
     // there's an extra space inserted after 99
     expect(cmb.getValue()).toBe("(+ 1 99 2 3)");
@@ -109,12 +107,12 @@ describe("focusing,", () => {
 
   it("inserting multiple nodes should put focus on the last of the new nodes", async () => {
     mouseDown(literal1);
-    await finishRender(cmb);
+    await finishRender();
     keyDown("]", { ctrlKey: true });
-    await finishRender(cmb);
+    await finishRender();
     insertText("99 88 77");
     keyDown("Enter");
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toBe("(+ 1 99 88 77 2 3)");
     // TODO(Emmanuel): does getFocusedNode().value always return strings?
     expect((cmb.getFocusedNode() as Literal).value).toBe("77");

--- a/spec/markText-test.ts
+++ b/spec/markText-test.ts
@@ -18,7 +18,7 @@ describe("The CodeMirrorBlocks Class", function () {
     beforeEach(async function () {
       cmb = await mountCMB(wescheme);
       cmb.setValue("11\n12\n(+ 3 4 5)");
-      await finishRender(cmb); // give the editor a chance to re-render
+      await finishRender(); // give the editor a chance to re-render
       cmb.getAllMarks().forEach((m) => m.clear());
       ast = cmb.getAst();
       literal1 = ast.rootNodes[0];
@@ -118,7 +118,7 @@ describe("The CodeMirrorBlocks Class", function () {
             expect(cmb.getAllMarks().length).toBe(1); 
             expect(literal1.element.style.background).toBe('red');
             cmb.setBlockMode(false);
-            await finishRender(cmb);
+            await finishRender();
             debugLog(cmb.getAllMarks());
             expect(cmb.getAllMarks().length).toBe(1);
           });

--- a/spec/new-blocks-test.ts
+++ b/spec/new-blocks-test.ts
@@ -71,17 +71,17 @@ describe("The CodeMirrorBlocks Class", function () {
     let literal!: ASTNode;
     beforeEach(async function () {
       cmb.setValue("11");
-      await finishRender(cmb);
+      await finishRender();
       cmb.setBlockMode(true);
-      await finishRender(cmb);
+      await finishRender();
       literal = cmb.getAst().rootNodes[0];
-      await finishRender(cmb);
+      await finishRender();
     });
 
     describe("when dealing with top-level input,", function () {
       beforeEach(async function () {
         cmb.setValue("42\n11");
-        await finishRender(cmb);
+        await finishRender();
       });
 
       it("typing at the end of a line", async function () {
@@ -102,7 +102,7 @@ describe("The CodeMirrorBlocks Class", function () {
         );
         await wait(QUARANTINE_DELAY);
         click(literal);
-        await finishRender(cmb);
+        await finishRender();
         expect(cmb.getValue()).toEqual("42\n9\n11");
       });
       it("typing at the beginning of a line", async function () {
@@ -113,14 +113,14 @@ describe("The CodeMirrorBlocks Class", function () {
         );
         await wait(QUARANTINE_DELAY);
         click(literal);
-        await finishRender(cmb);
+        await finishRender();
         expect(cmb.getValue()).toEqual("9\n42\n11");
       });
       it("typing between two blocks on a line", async function () {
         cmb.setCursor({ line: 0, ch: 3 });
         keyDown("9", {}, cmb.getInputField());
         insertText("9");
-        await finishRender(cmb);
+        await finishRender();
         expect(cmb.getValue()).toEqual("429\n11");
       });
 
@@ -129,36 +129,36 @@ describe("The CodeMirrorBlocks Class", function () {
     /*
     it('should begin editing a node on click', async function() {
       click(literal);
-      await finishRender(cmb);
+      await finishRender();
       expect(document.activeElement.classList).toContain('blocks-editing');
     });
     
     it('should save a valid, edited node on blur', async function() {
       click(literal);
-      await finishRender(cmb);
+      await finishRender();
       insertText("9");
-      await finishRender(cmb);
+      await finishRender();
       keyDown("Enter");
-      await finishRender(cmb);
+      await finishRender();
       expect(cmb.getValue()).toEqual('9');
     })
     */
     it("should not allow required blanks to be deleted", async function () {
       cmb.setValue("()");
-      await finishRender(cmb);
+      await finishRender();
       cmb.getValue("(...)"); // blank should be inserted by parser, as '...'
       const blank = (cmb.getAst().rootNodes[0] as FunctionApp).func;
       click(blank.element);
-      await finishRender(cmb);
+      await finishRender();
       expect(blank.isEditable()).toBe(true);
       keyDown("Delete");
-      await finishRender(cmb);
+      await finishRender();
       cmb.getValue("(...)"); // deleting the blank should be a no-op
     });
 
     it("should return the node being edited on ESC", async function () {
       click(literal);
-      await finishRender(cmb);
+      await finishRender();
       const quarantine = document.activeElement;
       keyDown("Escape", {}, quarantine);
       expect(cmb.getValue()).toEqual("11");
@@ -166,16 +166,16 @@ describe("The CodeMirrorBlocks Class", function () {
 
     it("should blur the node being edited on enter", async function () {
       click(literal);
-      await finishRender(cmb);
+      await finishRender();
       let quarantine = document.activeElement;
       keyDown("Enter");
-      await finishRender(cmb);
+      await finishRender();
       expect(document.activeElement).not.toBe(undefined);
     });
 
     it("should blur the node being edited on top-level click", async function () {
       click(literal.element);
-      await finishRender(cmb);
+      await finishRender();
       click(cmb.getWrapperElement());
       expect(document.activeElement).not.toBe(undefined);
     });
@@ -184,7 +184,7 @@ describe("The CodeMirrorBlocks Class", function () {
       beforeEach(async function () {
         spyOn(cmb, "replaceRange");
         click(literal.element);
-        await finishRender(cmb);
+        await finishRender();
         let quarantine = document.activeElement;
         let selection = window.getSelection();
         expect(selection.rangeCount).toEqual(1);
@@ -213,7 +213,7 @@ describe("The CodeMirrorBlocks Class", function () {
 
       beforeEach(async function () {
         cmb.setValue("(+ 1 2) (+)");
-        await finishRender(cmb);
+        await finishRender();
         ast = cmb.getAst();
         firstRoot = ast.rootNodes[0];
         firstArg = (ast.rootNodes[0] as FunctionApp).args[0];
@@ -241,28 +241,28 @@ describe("The CodeMirrorBlocks Class", function () {
       it("Ctrl-[ should activate a quarantine to the left", async function () {
         mouseDown(firstArg.element);
         keyDown("[", { ctrlKey: true });
-        await finishRender(cmb);
+        await finishRender();
         //expect(cmb.setQuarantine).toHaveBeenCalled();
       });
 
       it("Ctrl-] should activate a quarantine to the right", async function () {
         mouseDown(firstArg.element);
         keyDown("]", { ctrlKey: true }, firstArg.element);
-        await finishRender(cmb);
+        await finishRender();
         //expect(cmb.setQuarantine).toHaveBeenCalled();
       });
 
       it("Ctrl-] should activate a quarantine in the first arg position", async function () {
         mouseDown(blank.func.element);
-        await finishRender(cmb);
+        await finishRender();
         keyDown("]", { ctrlKey: true }, blank.func.element);
-        await finishRender(cmb);
+        await finishRender();
         //expect(cmb.setQuarantine).toHaveBeenCalled();
       });
 
       it("should activate a quarantine on dblclick", async function () {
         click(whiteSpaceEl);
-        await finishRender(cmb);
+        await finishRender();
         //expect(cmb.setQuarantine).toHaveBeenCalled();
       });
 
@@ -274,7 +274,7 @@ describe("The CodeMirrorBlocks Class", function () {
 
         beforeEach(async function () {
           cmb.setValue("(f)");
-          await finishRender(cmb);
+          await finishRender();
           ast = cmb.getAst();
           firstRoot = ast.rootNodes[0];
           func = (ast.rootNodes[0] as FunctionApp).func;
@@ -286,7 +286,7 @@ describe("The CodeMirrorBlocks Class", function () {
         it("should allow editing the argument whitespace", async function () {
           /* left off here*/
           click(argWS);
-          await finishRender(cmb);
+          await finishRender();
           //expect(cmb.setQuarantine).toHaveBeenCalled();
         });
       });
@@ -296,13 +296,13 @@ describe("The CodeMirrorBlocks Class", function () {
         // see https://github.com/bootstrapworld/codemirror-blocks/issues/123
         // it('should save whiteSpace on blur', async function() {
         //   whiteSpaceEl.dispatchEvent(dblclick());
-        //   await finishRender(cmb);
+        //   await finishRender();
         //   expect(trackSetQuarantine).toHaveBeenCalledWith("", whiteSpaceEl);
         //   let quarantine = trackSetQuarantine.calls.mostRecent().returnValue;
         //   let trackOnBlur = spyOn(quarantine, 'onblur').and.callThrough();
         //   quarantine.appendChild(document.createTextNode('4253'));
         //   quarantine.dispatchEvent(blur());
-        //   await finishRender(cmb);
+        //   await finishRender();
         //   expect(trackOnBlur).toHaveBeenCalled();
         //   expect(trackSaveEdit).toHaveBeenCalledWith(quarantine);
         //   expect(quarantine.textContent).toBe('4253'); // confirms text=4253 inside saveEdit, blocks.js line 495
@@ -316,7 +316,7 @@ describe("The CodeMirrorBlocks Class", function () {
         // it('should blur whitespace you are editing on enter', async function() {
         //   whiteSpaceEl.dispatchEvent(dblclick());
         //   let quarantine = trackSetQuarantine.calls.mostRecent().returnValue;
-        //   await finishRender(cmb);
+        //   await finishRender();
         //   quarantine.dispatchEvent(keydown(ENTER));
         //   expect(trackHandleChange).toHaveBeenCalled();
         // });
@@ -324,7 +324,7 @@ describe("The CodeMirrorBlocks Class", function () {
         describe('when "saving" bad whitepspace inputs,', function () {
           beforeEach(async function () {
             // whiteSpaceEl.dispatchEvent(dblclick());
-            // await finishRender(cmb);
+            // await finishRender();
             // quarantine = trackSetQuarantine.calls.mostRecent().returnValue;
             // quarantine.appendChild(document.createTextNode('"moo'));
             // quarantine.dispatchEvent(blur());

--- a/spec/undo-redo-test.ts
+++ b/spec/undo-redo-test.ts
@@ -35,54 +35,52 @@ describe("when testing undo/redo,", () => {
     cmb = await mountCMB(wescheme);
   });
 
-  afterEach(() => {
-    teardown();
-  });
+  afterEach(teardown);
 
   // https://github.com/bootstrapworld/codemirror-blocks/issues/315
   it("make sure edits can be properly undone/redone from an active block", async () => {
     cmb.setValue(`A\nB\n`);
     cmb.clearHistory();
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.historySize()).toEqual({ undo: 0, redo: 0 });
     mouseDown(currentFirstRoot()); // focus on the 1st root
     keyDown(" ", {}, currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     keyDown("X", cmd_ctrl, currentFirstRoot()); // change (1): cut first root
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 1, redo: 0 });
     cmb.setCursor({ line: 2, ch: 0 });
     keyDown("Enter"); // change (2): insert empty line
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n\n");
     expect(cmb.historySize()).toEqual({ undo: 2, redo: 0 });
     insertText("C"); // change (3): insert C at the end
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n\nC");
     expect(cmb.historySize()).toEqual({ undo: 3, redo: 0 });
     undo(currentFirstRoot()); // undo (3), leaving \nB\n\n
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n\n");
     expect(cmb.historySize()).toEqual({ undo: 2, redo: 1 });
     undo(currentFirstRoot()); // undo (2), leaving \nB\n\n
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 1, redo: 2 });
     undo(currentFirstRoot()); // undo (1), leaving A\nB\n
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("A\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 0, redo: 3 });
     redo(currentFirstRoot()); // redo (1), leaving \nB\n
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 1, redo: 2 });
     redo(currentFirstRoot()); // redo (2), leaving \nB\n\n
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n\n");
     expect(cmb.historySize()).toEqual({ undo: 2, redo: 1 });
     redo(currentFirstRoot()); // redo (3), leaving \nB\n\nC
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n\nC");
     expect(cmb.historySize()).toEqual({ undo: 3, redo: 0 });
   });
@@ -90,19 +88,19 @@ describe("when testing undo/redo,", () => {
   it("make sure edits can be properly undone/redone from the top level", async () => {
     cmb.setValue(`A\nB\n`);
     cmb.clearHistory();
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.historySize()).toEqual({ undo: 0, redo: 0 });
 
     mouseDown(currentFirstRoot()); // focus on the 1st root
     keyDown(" ", {}, currentFirstRoot());
-    await finishRender(cmb);
+    await finishRender();
     keyDown("X", cmd_ctrl, currentFirstRoot()); // change (1): cut first root
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 1, redo: 0 });
     cmb.setCursor({ line: 1, ch: 0 });
     undo(); // initiate undo from the top-level
-    await finishRender(cmb);
+    await finishRender();
     expect(cmb.getValue()).toEqual("A\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 0, redo: 1 });
     redo(); // initiate redo from the top-level

--- a/src/toolkit/test-utils.ts
+++ b/src/toolkit/test-utils.ts
@@ -1,6 +1,6 @@
 import CodeMirrorBlocks, { API, Language } from "../CodeMirrorBlocks";
 import { cleanup } from "@testing-library/react";
-import { afterAllDOMUpdates } from "../utils";
+import { afterAllDOMUpdates, cancelAllDOMUpdates } from "../utils";
 import type { ASTNode } from "../ast";
 // pass along all the simulated events
 export * from "./simulate";
@@ -36,6 +36,7 @@ export function removeEventListeners() {
 }
 
 export function teardown() {
+  cancelAllDOMUpdates();
   cleanup();
   const rootNode = document.getElementById("root");
   if (rootNode) {

--- a/src/toolkit/test-utils.ts
+++ b/src/toolkit/test-utils.ts
@@ -25,7 +25,7 @@ export async function wait(ms: number) {
 
 // wait for the editor to finish rendering and for any
 // other async DOM tasks to finish
-export function finishRender(editor: API) {
+export function finishRender() {
   return afterAllDOMUpdates();
 }
 
@@ -82,9 +82,9 @@ export async function mountCMB(language: Language): Promise<API> {
     language,
     cmOptions
   );
-  await finishRender(cmb);
+  await finishRender();
   cmb.setBlockMode(true);
-  await finishRender(cmb);
+  await finishRender();
   return cmb;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,6 +100,19 @@ export function cancelAfterDOMUpdate(handle: afterDOMUpdateHandle): void {
 }
 
 /**
+ * Cancels all pendings calls to {@link setAfterDOMUpdate}
+ *
+ * This should only be used in testing environments.
+ *
+ * @internal
+ */
+export function cancelAllDOMUpdates() {
+  for (const handle of uncompletedDOMUpdates) {
+    cancelAfterDOMUpdate(handle);
+  }
+}
+
+/**
  * Waits for all outstanding calls to setAfterDOMUpdate to finish or
  * be cancelled.
  *
@@ -545,7 +558,7 @@ export function playSound(sound: CustomAudio) {
 }
 
 export function debugLog(...args: any[]) {
-  if (process.env.DEBUG) {
+  if (global?.process?.env?.DEBUG) {
     console.log(...args);
   }
 }


### PR DESCRIPTION
Found another test/async problem. Sometimes tests would call functions that would call afterDOMUpdate, then the test would finish, then the next test would run, and then the callback from the previous test would execute, potentially affecting the state of the current test.

This PR fixes the issue by cancelling all outstanding afterDOMUpdate callbacks during teardown.

There is also some other minor cleanup that does not change any behavior: 
 - removing unused arguments to finishRender()) 
 - passing teardown directly to afterEach, instead of wrapping it in its own function