### PR TITLE
Stop passing appElement through numerous component layers just for Modal.setAppElement

### DIFF
--- a/src/CodeMirrorBlocks.tsx
+++ b/src/CodeMirrorBlocks.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import Modal from "react-modal";
 import ToggleEditor from "./ui/ToggleEditor";
 import Args from "./components/Args";
 import * as DropTarget from "./components/DropTarget";
@@ -100,12 +101,15 @@ function CodeMirrorBlocks(
       language={language}
       initialCode={initialCode == null ? "" : initialCode}
       api={api}
-      appElement={container}
       options={options}
       cmOptions={cmOptions}
     />,
     container
   );
+  // See http://reactcommunity.org/react-modal/examples/set_app_element/
+  // Used to hide the application from screen readers while a modal
+  // is open.
+  Modal.setAppElement(container);
   return api;
 }
 

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,15 +1,8 @@
-import React, {
-  KeyboardEvent,
-  ReactElement,
-  useEffect,
-  useRef,
-  useCallback,
-} from "react";
+import React, { KeyboardEvent, ReactElement, useRef, useCallback } from "react";
 import Modal from "react-modal";
 import "../less/Dialog.less";
 
 type Props = {
-  appElement: string | HTMLElement;
   closeFn: () => void;
   isOpen: boolean;
   body: {
@@ -20,13 +13,9 @@ type Props = {
 };
 
 const Dialog = (props: Props) => {
-  const { appElement, isOpen, closeFn, keyUp, body } = props;
+  const { isOpen, closeFn, keyUp, body } = props;
   const headerRef = useRef<HTMLHeadingElement>(null);
   const focusTitle = useCallback(() => headerRef.current.focus(), []);
-
-  useEffect(() => {
-    Modal.setAppElement(appElement);
-  }, []);
 
   const onKeyUp = (e: KeyboardEvent): void => {
     if (e.key === "Escape") closeFn();

--- a/src/ui/Search.tsx
+++ b/src/ui/Search.tsx
@@ -19,9 +19,7 @@ export default function attachSearch(
     return acc;
   }, {} as { [index: number]: unknown });
 
-  type Props = GetProps<BlockEditorComponentClass> & {
-    appElement: HTMLElement;
-  };
+  type Props = GetProps<BlockEditorComponentClass>;
 
   type State = {
     showSearchDialog: boolean;
@@ -185,7 +183,6 @@ export default function attachSearch(
           <Dialog
             isOpen={this.state.showSearchDialog}
             closeFn={this.handleCloseModal}
-            appElement={this.props.appElement}
             keyUp={this.handleKeyModal}
             body={{ title: "Search Settings", content: content }}
           ></Dialog>

--- a/src/ui/ToggleEditor.tsx
+++ b/src/ui/ToggleEditor.tsx
@@ -309,7 +309,6 @@ export type ToggleEditorProps = {
   language: Language;
   options?: Options;
   api?: API;
-  appElement: HTMLElement;
   debuggingLog?: {
     history?: unknown;
   };
@@ -618,7 +617,6 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
         </div>
 
         <Dialog
-          appElement={this.props.appElement}
           isOpen={!!this.state.dialog}
           body={this.state.dialog}
           closeFn={() => this.setState({ dialog: null })}
@@ -653,7 +651,6 @@ class ToggleEditor extends Component<ToggleEditorProps, ToggleEditorState> {
         api={this.props.api}
         passedAST={this.ast}
         // the props below are unique to the BlockEditor
-        appElement={this.props.appElement}
         languageId={this.props.language.id}
         options={{ ...defaultOptions, ...this.props.options }}
       />


### PR DESCRIPTION
`Modal.setAppElement()` should only be called once for the entire application, so arguably it shouldn't even be called from codemirror-blocks since codemirror-blocks isn't an application, but a library that gets embedded in an application. This PR at least brings us closer to the ideal of `setAppElement` being called by the embedding application by moving the call to the entry point to codemirror-blocks.