### PR TITLE
Remove some unnecessary/unused properties from the AST class

### DIFF
--- a/spec/ast-test.ts
+++ b/spec/ast-test.ts
@@ -1,9 +1,6 @@
 import CodeMirror from "codemirror";
 import { AST } from "../src/CodeMirrorBlocks";
 import { FunctionApp, Literal, Sequence, Comment } from "../src/nodes";
-import { debugLog } from "../src/utils";
-
-debugLog("Doing ast-test.js");
 
 describe("The Literal Class", () => {
   it("should be constructed with a value and data type", () => {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -53,20 +53,14 @@ export const prettyPrintingWidth = 80;
  * are required to spit out an `AST` instance.
  */
 export class AST {
-  rootNodes: ASTNode[];
-  reverseRootNodes: ASTNode[];
-  nodeIdMap: Map<string, ASTNode>;
-  nodeNIdMap: Map<number, ASTNode>;
-  id: number;
-  hash: any;
+  readonly rootNodes: ASTNode[];
+  readonly nodeIdMap: Map<string, ASTNode>;
+  readonly nodeNIdMap: Map<number, ASTNode>;
 
   constructor(rootNodes: ASTNode[], annotate = true) {
     // the `rootNodes` attribute simply contains a list of the top level nodes
     // that were parsed, in srcLoc order
     this.rootNodes = rootNodes;
-    this.rootNodes.sort((a, b) => poscmp(a.from, b.from));
-    // the `reverseRootNodes` attribute is a shallow, reversed copy of the rootNodes
-    this.reverseRootNodes = rootNodes.slice().reverse();
 
     // *Unique* ID for every newly-parsed node. No ID is ever re-used.
     this.nodeIdMap = new Map();
@@ -76,10 +70,9 @@ export class AST {
     // When an AST is to be used by CMB, it must be annotated.
     // This step is computationally intensive, and in certain instances
     // unecessary
-    if (annotate) this.annotateNodes();
-
-    this.id = -1; // just for the sake of having an id, though unused
-    this.hash = hashObject(this.rootNodes.map((node) => node.hash));
+    if (annotate) {
+      this.annotateNodes();
+    }
   }
 
   /**
@@ -176,7 +169,7 @@ export class AST {
    * validateNode : ASTNode -> Void
    * Raise an exception if a Node has is invalid
    */
-  validateNode(node: ASTNode) {
+  private validateNode(node: ASTNode) {
     const astFieldNames = [
       "from",
       "to",
@@ -580,13 +573,13 @@ export abstract class ASTNode<
   // based on the depth level, choose short v. long descriptions
   describe(level: number) {
     if (this.level - level >= descDepth) {
-      return this.shortDescription(level);
+      return this.shortDescription();
     } else {
       return this.longDescription(level);
     }
   }
   // the short description is literally the ARIA label
-  shortDescription(level?: number): string {
+  shortDescription(): string {
     return this.options["aria-label"] || "";
   }
 

--- a/src/edits/patchAst.ts
+++ b/src/edits/patchAst.ts
@@ -1,4 +1,5 @@
-import type { AST, ASTNode } from "../ast";
+import type { AST } from "../ast";
+import { ASTNode } from "../ast";
 import { assert } from "../utils";
 
 // defaultdict with empty list
@@ -30,7 +31,9 @@ function copyAllIds(oldTree: ASTNode, newTree: ASTNode) {
 
 export default function unify(oldTree: AST, newTree: AST) {
   function loop(oldTree: ASTNode | AST, newTree: ASTNode | AST) {
-    newTree.id = oldTree.id;
+    if (newTree instanceof ASTNode && oldTree instanceof ASTNode) {
+      newTree.id = oldTree.id;
+    }
     const index: { [key: string]: ASTNode[] } = {};
     for (const oldNode of oldTree.children()) {
       addIndex(index, oldNode.hash, oldNode);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -311,7 +311,9 @@ export function getRoot(node: ASTNode) {
 export function getLastVisibleNode(state: RootState) {
   const { collapsedList, ast } = state;
   const collapsedNodeList = collapsedList.map(ast.getNodeById);
-  const lastNode = ast.getNodeBeforeCur(ast.reverseRootNodes[0].to);
+  const lastNode = ast.getNodeBeforeCur(
+    ast.rootNodes[ast.rootNodes.length - 1].to
+  );
   return skipWhile(
     (node) =>
       !!node &&


### PR DESCRIPTION
Started working on some more complicated tests and found these unnecessary/unused properties laying around.

I'm thinking the language definition object (the one with the parse method) could have a more simplified API. Right now we require the parse() method to return an `AST` object, which it must construct by passing in subclasses of `ASTNode`, which creates this coupling between the language definitions and what are otherwise codemirror-blocks internal data structures. It also leaks internal implementation details out of codemirror-blocks because the language definitions can access internal-only properties of ASTNode.

I'm thinking a more data-oriented API would be better where the parse() method in a language definition just returns a plain array of json-serializable objects that conform to a particular interface. The render() method that subclasses of ASTNode override would be separate from the json-serializable data that represents the actual AST.

I'm not going to do all that in this PR, but curious if you have any thoughts about it.