### PR TITLE
Replace onSuccess/onError callbacks for edit operations with just returning a result object

### DIFF
--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -103,30 +103,27 @@ const NodeEditable = (props: Props) => {
       }
 
       let annt = `${props.isInsertion ? "inserted" : "changed"} ${value}`;
-      const onSuccess = () => {
-        dispatch(activateByNid(props.cm, null, { allowMove: false }));
-        props.onChange(null);
-        props.onDisableEditable();
-        setErrorId("");
-        say(annt);
-      };
-      const onError = (e: any) => {
-        console.error(e);
-        setErrorId(target.node ? target.node.id : "editing");
-        if (element.current) {
-          selectElement(element.current, false);
-        }
-      };
-      insert(
+      const result = insert(
         getState(),
         dispatch,
         value,
         target,
         props.cm,
-        onSuccess,
-        onError,
         annt
       );
+      if (result.successful) {
+        dispatch(activateByNid(props.cm, null, { allowMove: false }));
+        props.onChange(null);
+        props.onDisableEditable();
+        setErrorId("");
+        say(annt);
+      } else {
+        console.error(result.exception);
+        setErrorId(target.node ? target.node.id : "editing");
+        if (element.current) {
+          selectElement(element.current, false);
+        }
+      }
     });
   };
 

--- a/src/edits/performEdits.ts
+++ b/src/edits/performEdits.ts
@@ -86,9 +86,6 @@ export function edit_replace(text: string, node: ASTNode): Edit {
   }
 }
 
-export type OnSuccess = (r: { newAST: AST; focusId?: string }) => void;
-export type OnError = (e: any) => void;
-
 export type PerformEditState = Pick<
   RootState,
   "ast" | "focusId" | "collapsedList"
@@ -107,21 +104,10 @@ export function usePerformEdits() {
       edits: Edit[],
       parse: (code: string) => AST,
       cm: Editor,
-      onSuccess: OnSuccess = (r: { newAST: AST; focusId: string }) => {},
-      onError: OnError = (e: any) => {},
       annt?: string
-    ) =>
-      performEdits(
-        state,
-        dispatch,
-        origin,
-        edits,
-        parse,
-        cm,
-        onSuccess,
-        onError,
-        annt
-      ),
+    ) => {
+      return performEdits(state, dispatch, origin, edits, parse, cm, annt);
+    },
     [state.ast, state.focusId, state.collapsedList]
   );
 }
@@ -142,11 +128,6 @@ export function performEdits(
   edits: Edit[],
   parse: (code: string) => AST,
   cm: Editor,
-  onSuccess: OnSuccess = (r: {
-    newAST: AST;
-    focusId?: string | undefined;
-  }) => {},
-  onError: OnError = (e: any) => {},
   annt?: string
 ): Result<{ newAST: AST; focusId?: string | undefined }> {
   // Use the focus hint from the last edit provided.
@@ -200,16 +181,12 @@ export function performEdits(
         result.newAST,
         annt
       );
-      if (changeResult.successful) {
-        onSuccess(changeResult.value);
-      }
       return changeResult;
     } catch (e) {
       logResults(getReducerActivities(), e);
       return err(e);
     }
   } else {
-    onError(result.exception);
     return err(result.exception);
   }
 }


### PR DESCRIPTION
Depends on #444.

The use of callbacks is unnecessary here and obfuscates the fact that these operations are actually synchronous. Returning a result object is a better way to return "values that might be errors but which don't need to be handled".