### PR TITLE
Make pretty() method on ASTNode abstract

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -609,12 +609,6 @@ export abstract class ASTNode<
     return this.pretty().display(prettyPrintingWidth).join("\n");
   }
 
-  // Pretty-printing is node-specific, and must be implemented by
-  // the ASTNode itself
-  pretty(): P.Doc {
-    throw new Error("Method not implemented.");
-  }
-
   // Produces an iterator over the children of this node.
   children(): Iterable<ASTNode> {
     return this.spec.children(this);
@@ -643,6 +637,10 @@ export abstract class ASTNode<
   reactElement(props?: Props): React.ReactElement {
     return renderASTNode({ node: this, ...props });
   }
+
+  // Pretty-printing is node-specific, and must be implemented by
+  // the ASTNode itself
+  abstract pretty(): P.Doc;
 
   abstract render(props: Props): React.ReactElement | void;
 }

--- a/src/edits/fakeAstEdits.ts
+++ b/src/edits/fakeAstEdits.ts
@@ -246,6 +246,9 @@ export class ClonedASTNode extends ASTNode {
   render(_props: {}) {
     warn("fakeAstEdits", "ClonedASTNode didn't expect to be rendered!");
   }
+  pretty(): P.Doc {
+    throw new Error("ClonedASTNode didn't expect to be prettied!");
+  }
 }
 
 // Make a copy of a node, to perform fake edits on (so that the fake edits don't


### PR DESCRIPTION
Having it implemented would nullify the check that happens in `validateNode`.