### PR TITLE
Make RootState.markedMap (and others) typed as immutable

### DIFF
--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -317,7 +317,7 @@ const ConnectedNode = (props: ConnectedNodeProps) => {
       return {
         isSelected: selections.includes(node.id),
         isCollapsed: collapsedList.includes(node.id),
-        textMarker: markedMap.get(node.id),
+        textMarker: markedMap[node.id],
       };
     }
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -246,7 +246,7 @@ export function warn(origin: string, message: string) {
   console.warn(`CodeMirrorBlocks - ${origin} - ${message}`);
 }
 
-export function partition<T>(arr: T[], f: (i: T) => boolean) {
+export function partition<T>(arr: Readonly<T[]>, f: (i: T) => boolean) {
   const matched: T[] = [];
   const notMatched: T[] = [];
   for (const e of arr) {


### PR DESCRIPTION
A couple of things here. Redux state is supposed to be immutable. The `readonly` type in typescript protects against mutability at the property level, but it allows internal mutations to happen. `RootState.markedMap` was using a `Map()` object, and the reducer was calling `makedMap.set()` and `markedMap.delete()` which mutates the map internally. In addition, the `RESET_STORE_FOR_TESTING` action just returned the initialState object.

That's a problem:

```ts
let state1 = reduce(initialState, {type:"ADD_MARK", mark: someMark, id: "some-id"})
state1.markedMap.get("some-id"); // returns someMark

let state2 = reduce(state1, {type: "RESET_STORE_FOR_TESTING"});
state2.markedMap.get("some-id"); // returns..... someMark!
```

So whenever we used RESET_STORE_FOR_TESTING, it wouldn't actually reset the store to the initial state, because the initialState was referring to the same Map instance that ADD_MARK and CLEAR_MARK were mutating directly, rather than replacing in the state.

Now when you stick RESET_STORE_FOR_TESTING inside of a teardown for a test suite, the mutations performed in the previous test leak into the state being used for the next step... and now the order in which tests are run affect whether they pass or not.

This PR fixes this issue.