### PR TITLE
throw an error if setAfterDOMUpdate is given a non-function value

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,6 +83,10 @@ export function setAfterDOMUpdate(
   callback: () => void,
   extraDelay?: number
 ): afterDOMUpdateHandle {
+  if (!(typeof callback == "function")) {
+    console.error("setAfterDOMUpdate given a non-function value:", callback);
+    throw "setAfterDOMUpdate given a non-function value";
+  }
   const handle: afterDOMUpdateHandle = {
     raf: window.requestAnimationFrame(() => {
       handle.timeout = setTimeout(() => {


### PR DESCRIPTION
I'm assuming this is pretty straightforward - throw an error if the callback doesn't have the proper type