### PR TITLE
Make things that act like redux action creators into actual redux action creators

### DIFF
--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -93,35 +93,35 @@ const Node = (
       // codemirror hasn't mounted yet, do nothing.
       return;
     }
-    keyDown(e, {
-      isNodeEnv: true,
-      node: props.node,
-      editor: editor,
-      language: language,
-      search: search,
+    dispatch(
+      keyDown(e, {
+        isNodeEnv: true,
+        node: props.node,
+        editor: editor,
+        language: language,
+        search: search,
 
-      isLocked,
-      handleMakeEditable,
-      setLeft: () => {
-        const dropTargetId = findAdjacentDropTargetId(props.node, true);
-        if (dropTargetId) {
-          dispatch({ type: "SET_EDITABLE", id: dropTargetId, bool: true });
-        }
-        return !!dropTargetId;
-      },
-      setRight: () => {
-        const dropTargetId = findAdjacentDropTargetId(props.node, false);
-        if (dropTargetId) {
-          dispatch({ type: "SET_EDITABLE", id: dropTargetId, bool: true });
-        }
-        return !!dropTargetId;
-      },
-      normallyEditable: Boolean(props.normallyEditable),
-      expandable: props.expandable,
-      isCollapsed: props.isCollapsed,
-
-      dispatch,
-    });
+        isLocked,
+        handleMakeEditable,
+        setLeft: () => {
+          const dropTargetId = findAdjacentDropTargetId(props.node, true);
+          if (dropTargetId) {
+            dispatch({ type: "SET_EDITABLE", id: dropTargetId, bool: true });
+          }
+          return !!dropTargetId;
+        },
+        setRight: () => {
+          const dropTargetId = findAdjacentDropTargetId(props.node, false);
+          if (dropTargetId) {
+            dispatch({ type: "SET_EDITABLE", id: dropTargetId, bool: true });
+          }
+          return !!dropTargetId;
+        },
+        normallyEditable: Boolean(props.normallyEditable),
+        expandable: props.expandable,
+        isCollapsed: props.isCollapsed,
+      })
+    );
   };
   const handleClick = (e: React.MouseEvent) => {
     const { inToolbar, normallyEditable } = props;

--- a/src/components/NodeEditable.tsx
+++ b/src/components/NodeEditable.tsx
@@ -107,15 +107,8 @@ const NodeEditable = (props: Props) => {
       }
 
       let annt = `${props.isInsertion ? "inserted" : "changed"} ${value}`;
-      const result = insert(
-        getState(),
-        dispatch,
-        search,
-        value,
-        target,
-        props.editor,
-        language.parse,
-        annt
+      const result = dispatch(
+        insert(search, value, target, props.editor, language.parse, annt)
       );
       if (result.successful) {
         dispatch(

--- a/src/keymap.tsx
+++ b/src/keymap.tsx
@@ -22,9 +22,8 @@ import {
 import { say } from "./announcer";
 import { findAdjacentDropTargetId as getDTid } from "./components/DropTarget";
 
-import type { AppDispatch } from "./store";
+import type { AppThunk } from "./store";
 import type { ASTNode } from "./ast";
-import type { RootState } from "./reducers";
 import { KeyDownContext } from "./ui/ToggleEditor";
 import { CMBEditor } from "./editor";
 import { Language } from "./CodeMirrorBlocks";
@@ -33,7 +32,6 @@ import type { Search } from "./ui/BlockEditor";
 type BlockEditorEnv = {
   isNodeEnv: false;
   editor: CMBEditor;
-  dispatch: AppDispatch;
   language: Language;
   search: Search;
 };
@@ -49,8 +47,6 @@ type NodeEnv = {
   setRight: () => boolean;
   setLeft: () => boolean;
 
-  dispatch: AppDispatch;
-
   isCollapsed: boolean;
   expandable: boolean;
   normallyEditable: boolean;
@@ -60,7 +56,6 @@ type NodeEnv = {
 export type InputEnv = BlockEditorEnv | NodeEnv;
 
 type Env = InputEnv & {
-  state: RootState;
   fastSkip: (
     next: (node: ASTNode) => ASTNode | undefined
   ) => ASTNode | undefined;
@@ -159,78 +154,80 @@ Object.assign(defaultKeyMap, mac ? macKeyMap : pcKeyMap);
 // see https://codemirror.net/doc/manual.html#keymaps
 CodeMirror.normalizeKeyMap(defaultKeyMap);
 
-const pasteHandler = (env: Env, e: React.KeyboardEvent) => {
-  if (!env.isNodeEnv) {
-    return CodeMirror.Pass;
-  }
-  const before = e.shiftKey; // shiftKey=down => we paste BEFORE the active node
-  const pos = before ? env.node.srcRange().from : env.node.srcRange().to;
-  // Case 1: Overwriting selected nodes
-  if (env.state.selections.includes(env.node.id)) {
-    paste(
-      env.state,
-      env.dispatch,
-      env.editor,
-      env.search,
-      new ReplaceNodeTarget(env.node),
-      env.language.parse
-    );
-  }
-  // Case 2: Inserting to the left or right of the root
-  else if (!env.node.parent) {
-    paste(
-      env.state,
-      env.dispatch,
-      env.editor,
-      env.search,
-      new OverwriteTarget(pos, pos),
-      env.language.parse
-    );
-  }
-  // Case 3: Pasting to an adjacent dropTarget. Make sure it's a valid field!
-  else {
-    const DTnode = document.getElementById(
-      "block-drop-target-" + getDTid(env.node, before)
-    );
-    if (DTnode?.dataset?.field) {
-      // We're somewhere valid in the AST. Initiate paste on the target field!
-      paste(
-        env.state,
-        env.dispatch,
-        env.editor,
-        env.search,
-        new InsertTarget(env.node.parent, DTnode.dataset.field, pos),
-        env.language.parse
-      );
-    } else {
-      playSound(BEEP);
-      say(`Cannot paste ${e.shiftKey ? "before" : "after"} this node.`);
+const pasteHandler =
+  (env: Env, e: React.KeyboardEvent): AppThunk =>
+  (dispatch, getState) => {
+    if (!env.isNodeEnv) {
+      return;
     }
-  }
-};
+    const before = e.shiftKey; // shiftKey=down => we paste BEFORE the active node
+    const pos = before ? env.node.srcRange().from : env.node.srcRange().to;
+    // Case 1: Overwriting selected nodes
+    if (getState().selections.includes(env.node.id)) {
+      dispatch(
+        paste(
+          env.editor,
+          env.search,
+          new ReplaceNodeTarget(env.node),
+          env.language.parse
+        )
+      );
+    }
+    // Case 2: Inserting to the left or right of the root
+    else if (!env.node.parent) {
+      dispatch(
+        paste(
+          env.editor,
+          env.search,
+          new OverwriteTarget(pos, pos),
+          env.language.parse
+        )
+      );
+    }
+    // Case 3: Pasting to an adjacent dropTarget. Make sure it's a valid field!
+    else {
+      const DTnode = document.getElementById(
+        "block-drop-target-" + getDTid(env.node, before)
+      );
+      if (DTnode?.dataset?.field) {
+        // We're somewhere valid in the AST. Initiate paste on the target field!
+        dispatch(
+          paste(
+            env.editor,
+            env.search,
+            new InsertTarget(env.node.parent, DTnode.dataset.field, pos),
+            env.language.parse
+          )
+        );
+      } else {
+        playSound(BEEP);
+        say(`Cannot paste ${e.shiftKey ? "before" : "after"} this node.`);
+      }
+    }
+  };
 
 const commandMap: {
-  [index: string]: (env: Env, e: React.KeyboardEvent) => void;
+  [index: string]: (env: Env, e: React.KeyboardEvent) => void | AppThunk;
 } = {
   "Shift Focus": (env, e) => {
     e.preventDefault();
     KeyDownContext.toolbarRef.current?.focus();
   },
   // NAVIGATION
-  "Previous Block": (env, e) => {
+  "Previous Block": (env, e) => (dispatch, getState) => {
+    const state = getState();
     e.preventDefault();
     if (env.isNodeEnv) {
       let prev = env.fastSkip((node) => node.prev);
       if (prev) {
-        return env.dispatch(activateByNid(env.editor, env.search, prev.nid));
+        return dispatch(activateByNid(env.editor, env.search, prev.nid));
       } else {
         return playSound(BEEP);
       }
     }
-    const prevNode =
-      env.state.cur && env.state.ast.getNodeBeforeCur(env.state.cur);
+    const prevNode = state.cur && state.ast.getNodeBeforeCur(state.cur);
     return prevNode
-      ? env.dispatch(
+      ? dispatch(
           activateByNid(env.editor, env.search, prevNode.nid, {
             allowMove: true,
           })
@@ -238,20 +235,20 @@ const commandMap: {
       : playSound(BEEP);
   },
 
-  "Next Block": (env, e) => {
+  "Next Block": (env, e) => (dispatch, getState) => {
     e.preventDefault();
     if (env.isNodeEnv) {
       let next = env.fastSkip((node) => node.next);
       if (next) {
-        return env.dispatch(activateByNid(env.editor, env.search, next.nid));
+        return dispatch(activateByNid(env.editor, env.search, next.nid));
       } else {
         return playSound(BEEP);
       }
     }
-    const nextNode =
-      env.state.cur && env.state.ast.getNodeAfterCur(env.state.cur);
+    const { cur, ast } = getState();
+    const nextNode = cur && ast.getNodeAfterCur(cur);
     return nextNode
-      ? env.dispatch(
+      ? dispatch(
           activateByNid(env.editor, env.search, nextNode.nid, {
             allowMove: true,
           })
@@ -261,69 +258,69 @@ const commandMap: {
 
   "First Block": (env, _) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
-    env.dispatch(activateByNid(env.editor, env.search, 0, { allowMove: true }));
+    return activateByNid(env.editor, env.search, 0, { allowMove: true });
   },
 
-  "Last Visible Block": (env, _) => {
+  "Last Visible Block": (env, _) => (dispatch, getState) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     } else {
-      const lastVisible = getLastVisibleNode(env.state);
+      const lastVisible = getLastVisibleNode(getState());
       lastVisible &&
-        env.dispatch(activateByNid(env.editor, env.search, lastVisible.nid));
+        dispatch(activateByNid(env.editor, env.search, lastVisible.nid));
     }
   },
 
-  "Collapse or Focus Parent": (env, e) => {
+  "Collapse or Focus Parent": (env, e) => (dispatch) => {
     e.preventDefault();
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     if (env.expandable && !env.isCollapsed && !env.isLocked()) {
-      env.dispatch({ type: "COLLAPSE", id: env.node.id });
+      dispatch({ type: "COLLAPSE", id: env.node.id });
     } else if (env.node.parent) {
-      env.dispatch(activateByNid(env.editor, env.search, env.node.parent.nid));
+      dispatch(activateByNid(env.editor, env.search, env.node.parent.nid));
     } else {
       playSound(BEEP);
     }
   },
 
-  "Expand or Focus 1st Child": (env, e) => {
+  "Expand or Focus 1st Child": (env, e) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     const node = env.node;
     e.preventDefault();
     if (env.expandable && env.isCollapsed && !env.isLocked()) {
-      env.dispatch({ type: "UNCOLLAPSE", id: node.id });
+      dispatch({ type: "UNCOLLAPSE", id: node.id });
     } else if (node.next?.parent === node) {
-      env.dispatch(activateByNid(env.editor, env.search, node.next.nid));
+      dispatch(activateByNid(env.editor, env.search, node.next.nid));
     } else {
       playSound(BEEP);
     }
   },
 
-  "Collapse All": (env, _) => {
+  "Collapse All": (env, _) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
-    env.dispatch({ type: "COLLAPSE_ALL" });
-    env.dispatch(activateByNid(env.editor, env.search, getRoot(env.node).nid));
+    dispatch({ type: "COLLAPSE_ALL" });
+    dispatch(activateByNid(env.editor, env.search, getRoot(env.node).nid));
   },
 
   "Expand All": (env, _) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     } else {
-      return env.dispatch({ type: "UNCOLLAPSE_ALL" });
+      return (dispatch) => dispatch({ type: "UNCOLLAPSE_ALL" });
     }
   },
 
-  "Collapse Current Root": (env, _) => {
+  "Collapse Current Root": (env, _) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     if (!env.node.parent && (env.isCollapsed || !env.expandable)) {
       playSound(BEEP);
@@ -331,36 +328,34 @@ const commandMap: {
       let root = getRoot(env.node);
       let descendants = [...root.descendants()];
       descendants.forEach(
-        (d) => env.isNodeEnv && env.dispatch({ type: "COLLAPSE", id: d.id })
+        (d) => env.isNodeEnv && dispatch({ type: "COLLAPSE", id: d.id })
       );
-      env.dispatch(activateByNid(env.editor, env.search, root.nid));
+      dispatch(activateByNid(env.editor, env.search, root.nid));
     }
   },
 
-  "Expand Current Root": (env, _) => {
+  "Expand Current Root": (env, _) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     let root = getRoot(env.node);
     [...root.descendants()].forEach(
-      (d) => env.isNodeEnv && env.dispatch({ type: "UNCOLLAPSE", id: d.id })
+      (d) => env.isNodeEnv && dispatch({ type: "UNCOLLAPSE", id: d.id })
     );
-    env.dispatch(activateByNid(env.editor, env.search, root.nid));
+    dispatch(activateByNid(env.editor, env.search, root.nid));
   },
 
   "Jump to Root": (env, _) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     } else {
-      env.dispatch(
-        activateByNid(env.editor, env.search, getRoot(env.node).nid)
-      );
+      return activateByNid(env.editor, env.search, getRoot(env.node).nid);
     }
   },
 
   "Read Ancestors": (env, _) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     const parents = [env.node.shortDescription()];
     let next = env.node.parent;
@@ -377,7 +372,7 @@ const commandMap: {
 
   "Read Children": (env, _) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     } else {
       const description = env.node.describe(env.node.level);
       description && say(description);
@@ -385,9 +380,9 @@ const commandMap: {
   },
 
   // SEARCH, SELECTION & CLIPBOARD
-  "Toggle Selection": (env, e) => {
+  "Toggle Selection": (env, e) => (dispatch, getState) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     e.preventDefault();
     const node = env.node;
@@ -405,22 +400,20 @@ const commandMap: {
 
     // if the node is already selected, remove it, its descendants
     // and any ancestor
-    if (env.state.selections.includes(env.node.id)) {
-      const prunedSelection = env.state.selections
+    const { selections, ast } = getState();
+    if (selections.includes(env.node.id)) {
+      const prunedSelection = selections
         .filter((s) => !descendantIds(node).includes(s))
         .filter((s) => !ancestorIds(node).includes(s));
-      env.dispatch({
+      dispatch({
         type: "SET_SELECTIONS",
         selections: prunedSelection,
       });
       // TODO(Emmanuel): announce removal
     } else {
-      const isContained = (id: string) => env.state.ast.isAncestor(node.id, id);
-      const doesContain = (id: string) => env.state.ast.isAncestor(id, node.id);
-      let [removed, newSelections] = partition(
-        env.state.selections,
-        isContained
-      );
+      const isContained = (id: string) => ast.isAncestor(node.id, id);
+      const doesContain = (id: string) => ast.isAncestor(id, node.id);
+      let [removed, newSelections] = partition(selections, isContained);
       for (const _r of removed) {
         // TODO(Emmanuel): announce removal
       }
@@ -430,7 +423,7 @@ const commandMap: {
       } else {
         // TODO(Emmanuel): announce addition
         newSelections = newSelections.concat(descendantIds(node));
-        env.dispatch({
+        dispatch({
           type: "SET_SELECTIONS",
           selections: newSelections,
         });
@@ -438,18 +431,18 @@ const commandMap: {
     }
   },
 
-  Edit: (env, e) => {
+  Edit: (env, e) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     if (env.normallyEditable) {
       env.handleMakeEditable(e);
       e.preventDefault();
     } else if (env.expandable && !env.isLocked()) {
       if (env.isCollapsed) {
-        env.dispatch({ type: "UNCOLLAPSE", id: env.node.id });
+        dispatch({ type: "UNCOLLAPSE", id: env.node.id });
       } else {
-        env.dispatch({ type: "COLLAPSE", id: env.node.id });
+        dispatch({ type: "COLLAPSE", id: env.node.id });
       }
     } else {
       playSound(BEEP);
@@ -458,111 +451,101 @@ const commandMap: {
 
   "Edit Anything": (env, e) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     } else {
       return env.handleMakeEditable(e);
     }
   },
 
-  "Clear Selection": (env, _) => {
+  "Clear Selection": (env, _) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
-    env.dispatch({ type: "SET_SELECTIONS", selections: [] });
+    dispatch({ type: "SET_SELECTIONS", selections: [] });
   },
 
-  "Delete Nodes": (env, _) => {
+  "Delete Nodes": (env, _) => (dispatch, getState) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
-    if (!env.state.selections.length) {
+    const { selections, ast } = getState();
+    if (!selections.length) {
       return say("Nothing selected");
     }
-    const nodesToDelete = env.state.selections.map(
-      env.state.ast.getNodeByIdOrThrow
-    );
-    delete_(
-      env.state,
-      env.dispatch,
-      env.search,
-      env.editor,
-      nodesToDelete,
-      env.language.parse,
-      "deleted"
+    const nodesToDelete = selections.map(ast.getNodeByIdOrThrow);
+    dispatch(
+      delete_(
+        env.search,
+        env.editor,
+        nodesToDelete,
+        env.language.parse,
+        "deleted"
+      )
     );
   },
 
   // use the srcRange() to insert before/after the node *and*
   // any associated comments
-  "Insert Right": (env, _) => {
+  "Insert Right": (env, _) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     if (!env.setRight()) {
-      env.dispatch(setCursor(env.editor, env.node.srcRange().to, env.search));
+      dispatch(setCursor(env.editor, env.node.srcRange().to, env.search));
     }
   },
-  "Insert Left": (env, _) => {
+  "Insert Left": (env, _) => (dispatch) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     if (!env.setLeft()) {
-      env.dispatch(setCursor(env.editor, env.node.srcRange().from, env.search));
+      dispatch(setCursor(env.editor, env.node.srcRange().from, env.search));
     }
   },
 
-  Cut: (env, _) => {
+  Cut: (env, _) => (dispatch, getState) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
-    if (!env.state.selections.length) {
+    const { selections, ast } = getState();
+    if (!selections.length) {
       return say("Nothing selected");
     }
-    const nodesToCut = env.state.selections.map(
-      env.state.ast.getNodeByIdOrThrow
-    );
-    copy(env.state, nodesToCut, "cut");
-    delete_(
-      env.state,
-      env.dispatch,
-      env.search,
-      env.editor,
-      nodesToCut,
-      env.language.parse
-    );
+    const nodesToCut = selections.map(ast.getNodeByIdOrThrow);
+    copy(getState(), nodesToCut, "cut");
+    dispatch(delete_(env.search, env.editor, nodesToCut, env.language.parse));
   },
 
-  Copy: (env, _) => {
+  Copy: (env, _) => (dispatch, getState) => {
     if (!env.isNodeEnv) {
-      return CodeMirror.Pass;
+      return;
     }
     // if no nodes are selected, do it on focused node's id instead
-    const nodeIds = !env.state.selections.length
-      ? [env.node.id]
-      : env.state.selections;
-    const nodesToCopy = nodeIds.map(env.state.ast.getNodeByIdOrThrow);
-    copy(env.state, nodesToCopy, "copied");
+    const { selections, ast } = getState();
+    const nodeIds = !selections.length ? [env.node.id] : selections;
+    const nodesToCopy = nodeIds.map(ast.getNodeByIdOrThrow);
+    copy(getState(), nodesToCopy, "copied");
   },
 
   Paste: pasteHandler,
   "Paste Before": pasteHandler,
 
-  "Activate Search Dialog": (env, _) => {
+  "Activate Search Dialog": (env, _) => (dispatch, getState) => {
     env.search.onSearch(
       () => {},
       () =>
-        env.activateNoRecord(env.search.search(true, env.state) ?? undefined)
+        env.activateNoRecord(env.search.search(true, getState()) ?? undefined)
     );
   },
 
-  "Search Previous": (env, e) => {
+  "Search Previous": (env, e) => (dispatch, getState) => {
     e.preventDefault();
-    env.activateNoRecord(env.search.search(false, env.state) ?? undefined);
+    env.activateNoRecord(env.search.search(false, getState()) ?? undefined);
   },
 
-  "Search Next": (env, e) => {
+  "Search Next": (env, e) => (dispatch, getState) => {
     e.preventDefault();
-    env.activateNoRecord(env.search.search(true, env.state) ?? undefined);
+    env.activateNoRecord(env.search.search(true, getState()) ?? undefined);
   },
 
   Undo: (env, e) => doTopmostAction(env, e, "undo"),
@@ -577,62 +560,65 @@ const commandMap: {
   },
 };
 
-function doTopmostAction(
-  { state, editor: editor }: { state: RootState; editor: CMBEditor },
-  e: React.KeyboardEvent,
-  which: "undo" | "redo"
-) {
-  e.preventDefault();
-  const topmostAction = editor.getTopmostAction(which);
-  state.undoableAction = topmostAction.undoableAction;
-  state.actionFocus = topmostAction.actionFocus;
-  if (which === "undo") {
-    say(`UNDID: ${topmostAction.undoableAction}`);
-    editor.undo();
-  } else {
-    say(`REDID: ${topmostAction.undoableAction}`);
-    editor.redo();
-  }
-}
+const doTopmostAction =
+  ({ editor }: Env, e: React.KeyboardEvent, which: "undo" | "redo"): AppThunk =>
+  (dispatch, getState) => {
+    e.preventDefault();
+    const topmostAction = editor.getTopmostAction(which);
+    const state = getState();
+    state.undoableAction = topmostAction.undoableAction;
+    state.actionFocus = topmostAction.actionFocus;
+    if (which === "undo") {
+      say(`UNDID: ${topmostAction.undoableAction}`);
+      editor.undo();
+    } else {
+      say(`REDID: ${topmostAction.undoableAction}`);
+      editor.redo();
+    }
+  };
 
 // Recieves the key event, an environment (BlockEditor or Node), and the
 // editor's keyMap. If there is a handler for that event, add some utility
 // methods and call the handler with the environment.
-export function keyDown(e: React.KeyboardEvent, inputEnv: InputEnv) {
-  var handler = commandMap[defaultKeyMap[CodeMirror.keyName(e)]];
-  if (handler) {
-    e.stopPropagation();
-    inputEnv.dispatch((_, getState) => {
-      // set up the environment
-      const state = getState();
-      const env: Env = {
-        ...inputEnv,
-        state,
-        // add convenience methods
-        fastSkip: (next: (node: ASTNode) => ASTNode) =>
-          env.isNodeEnv ? skipCollapsed(env.node, next, state) : undefined,
-        activateNoRecord: (node?: ASTNode) => {
-          if (!node) {
-            return playSound(BEEP);
-          } // nothing to activate
-          env.dispatch(
-            activateByNid(env.editor, env.search, node.nid, {
-              record: false,
-              allowMove: true,
-            })
-          );
-        },
-      };
-      // If there's a node, make sure it's fresh
-      if (env.isNodeEnv) {
-        const updatedNode = state.ast.getNodeByIdOrThrow(env.node.id);
-        env.node =
-          updatedNode && state.ast.getNodeByNIdOrThrow(updatedNode.nid);
-      }
-      handler(env, e);
-    });
-  }
-}
+export const keyDown =
+  (e: React.KeyboardEvent, inputEnv: InputEnv): AppThunk =>
+  (dispatch) => {
+    const handler = commandMap[defaultKeyMap[CodeMirror.keyName(e)]];
+    if (handler) {
+      e.stopPropagation();
+      dispatch((dispatch, getState) => {
+        // set up the environment
+        const state = getState();
+        const env: Env = {
+          ...inputEnv,
+          // add convenience methods
+          fastSkip: (next: (node: ASTNode) => ASTNode) =>
+            env.isNodeEnv ? skipCollapsed(env.node, next, state) : undefined,
+          activateNoRecord: (node?: ASTNode) => {
+            if (!node) {
+              return playSound(BEEP);
+            } // nothing to activate
+            dispatch(
+              activateByNid(env.editor, env.search, node.nid, {
+                record: false,
+                allowMove: true,
+              })
+            );
+          },
+        };
+        // If there's a node, make sure it's fresh
+        if (env.isNodeEnv) {
+          const updatedNode = state.ast.getNodeByIdOrThrow(env.node.id);
+          env.node =
+            updatedNode && state.ast.getNodeByNIdOrThrow(updatedNode.nid);
+        }
+        const action = handler(env, e);
+        if (action) {
+          dispatch(action);
+        }
+      });
+    }
+  };
 
 const KeyMapTable = (props: { keyMap: KeyMap }) => {
   const { keyMap } = props;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,9 @@
 import { createStore, applyMiddleware } from "redux";
-import thunk, { ThunkDispatch, ThunkMiddleware } from "redux-thunk";
+import thunk, {
+  ThunkAction,
+  ThunkDispatch,
+  ThunkMiddleware,
+} from "redux-thunk";
 import { reducer } from "./reducers";
 import type { RootState, AppAction } from "./reducers";
 
@@ -18,3 +22,10 @@ export type AppStore = ReturnType<typeof createAppStore>;
  * AppActions and thunks.
  */
 export type AppDispatch = ThunkDispatch<RootState, unknown, AppAction>;
+
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  AppAction
+>;

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -325,16 +325,16 @@ class BlockEditor extends Component<BlockEditorProps> {
               actionFocus.oldFocusNId === null
                 ? null
                 : newAST.getNodeByNId(actionFocus.oldFocusNId);
-            commitChanges(
-              getState(),
-              dispatch,
-              this.props.search,
-              changes,
-              this.props.language.parse,
-              editor,
-              true,
-              focusHint,
-              this.newAST
+            dispatch(
+              commitChanges(
+                this.props.search,
+                changes,
+                this.props.language.parse,
+                editor,
+                true,
+                focusHint,
+                this.newAST
+              )
             );
             dispatch({ type: "UNDO", editor: editor });
           }
@@ -345,16 +345,16 @@ class BlockEditor extends Component<BlockEditorProps> {
             const { newFocusNId } = actionFocus;
             const focusHint = (newAST: AST) =>
               newFocusNId === null ? null : newAST.getNodeByNId(newFocusNId);
-            commitChanges(
-              getState(),
-              dispatch,
-              this.props.search,
-              changes,
-              this.props.language.parse,
-              editor,
-              true,
-              focusHint,
-              this.newAST
+            dispatch(
+              commitChanges(
+                this.props.search,
+                changes,
+                this.props.language.parse,
+                editor,
+                true,
+                focusHint,
+                this.newAST
+              )
             );
             dispatch({ type: "REDO", editor });
           }
@@ -370,16 +370,16 @@ class BlockEditor extends Component<BlockEditorProps> {
           }
           if (annt === "") annt = "change";
           getState().undoableAction = annt; //?
-          commitChanges(
-            getState(),
-            dispatch,
-            this.props.search,
-            changes,
-            this.props.language.parse,
-            editor,
-            false,
-            -1,
-            this.newAST
+          dispatch(
+            commitChanges(
+              this.props.search,
+              changes,
+              this.props.language.parse,
+              editor,
+              false,
+              -1,
+              this.newAST
+            )
           );
         }
       }
@@ -927,13 +927,14 @@ class BlockEditor extends Component<BlockEditorProps> {
             onFocus={this.handleTopLevelFocus}
             onPaste={this.handleTopLevelPaste}
             onKeyDown={(editor, e) => {
-              keyDown(e, {
-                search: this.props.search,
-                language: this.props.language,
-                editor,
-                isNodeEnv: false,
-                dispatch: this.props.dispatch,
-              });
+              this.props.dispatch(
+                keyDown(e, {
+                  search: this.props.search,
+                  language: this.props.language,
+                  editor,
+                  isNodeEnv: false,
+                })
+              );
             }}
             onCursorActivity={this.handleTopLevelCursorActivity}
             editorDidMount={this.handleEditorDidMount}


### PR DESCRIPTION
There was a common pattern where we would pass in a `dispatch` and `state` parameter to functions, which would then look at the state and dispatch various actions. This is just slightly different from how redux-thunk action creators are supposed to work. See [redux action creators docs](https://redux.js.org/usage/reducing-boilerplate#action-creators). This PR changes the code to match the pattern for redux-thunk action creators

The diff can be summarized as converting functions that look like:

```ts
function doSomething(dispatch: AppDispatch, state: RootState, ...someParams) {
  // look at someParams, look at state, etc.
  dispatch(/* some action */);
}

// then from a react component:
const dispatch: AppDispatch = useDispatch();
const store: AppStore = useStore();
doSomething(dispatch, store.getState(), ...someParams);
```

into functions that look like:

```ts
const doSomething = (...someParams) => (dispatch, getState()) => {
  // look at someParams, look at state through getState(), etc.
  dispatch(/* some action */);
};

// then from a react component:
const dispatch: AppDispatch = useDispatch();
dispatch(doSomething(...someParams));
```

Otherwise there's no change in logic. The main benefit is that it saves us from having to pass in the redux state everywhere.