### PR TITLE
Replace use of dispatchEvent with fireEvent to make react-testing-library happy

### DIFF
--- a/spec/drag-test.ts
+++ b/spec/drag-test.ts
@@ -17,9 +17,7 @@ import {
 import { API } from "../src/CodeMirrorBlocks";
 import { ASTNode } from "../src/ast";
 import { FunctionApp } from "../src/nodes";
-import { debugLog } from "../src/utils";
-
-debugLog("Doing drag-test.js");
+import { fireEvent } from "@testing-library/react";
 
 describe("Drag and drop", () => {
   let cmb!: API;
@@ -56,15 +54,15 @@ describe("Drag and drop", () => {
     it("should override nodes 1", () => {
       expect(secondArg.element!.textContent).toBe("2");
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
-      secondArg.element!.dispatchEvent(drop());
+      fireEvent(firstArg.element!, dragEvent);
+      fireEvent(secondArg.element!, drop());
       retrieve();
       expect(secondArg.element!.textContent).toBe("3");
     });
 
     it("should set the right css class on dragenter 2", () => {
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
+      fireEvent(firstArg.element!, dragEvent);
       let elt = dropTargetEls[3];
       expect(elt.classList).toContain("blocks-drop-target");
       dragenterSeq(elt);
@@ -73,14 +71,14 @@ describe("Drag and drop", () => {
 
     it("should set the right css class on dragenter 2’", () => {
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
+      fireEvent(firstArg.element!, dragEvent);
       let elt = secondArg;
       dragenterSeq(elt);
     });
 
     it("should set the right css class on dragleave 3", () => {
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
+      fireEvent(firstArg.element!, dragEvent);
       let elt = dropTargetEls[3];
       dragenter();
       dragleave();
@@ -89,7 +87,7 @@ describe("Drag and drop", () => {
 
     it("should do nothing when dragging over a non-drop target 4", () => {
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
+      fireEvent(firstArg.element!, dragEvent);
       let nonDT = cmb.getAst().rootNodes[0].element!;
       dragenterSeq(nonDT);
       expect(secondArg.element!.classList).not.toContain("blocks-over-target");
@@ -98,9 +96,9 @@ describe("Drag and drop", () => {
     it("should do nothing when dropping onto a non-drop target 5", () => {
       let initialValue = cmb.getValue();
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
+      fireEvent(firstArg.element!, dragEvent);
       let nonDT = cmb.getAst().rootNodes[0].element!;
-      nonDT.dispatchEvent(drop());
+      fireEvent(nonDT, drop());
       expect(cmb.getValue()).toBe(initialValue);
     });
 
@@ -108,15 +106,15 @@ describe("Drag and drop", () => {
       expect(dropTargetEls[3].classList).toContain("blocks-drop-target");
       // drag the first arg to the drop target
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
-      dropTargetEls[3].dispatchEvent(drop());
+      fireEvent(firstArg.element!, dragEvent);
+      fireEvent(dropTargetEls[3], drop());
       expect(cmb.getValue().replace(/\s+/, " ")).toBe("(+ 2 3 1)");
     });
 
     it("should update the text on drop to an earlier point in the file 7", () => {
       let dragEvent = dragstart();
-      secondArg.element!.dispatchEvent(dragEvent);
-      dropTargetEls[0].dispatchEvent(drop());
+      fireEvent(secondArg.element!, dragEvent);
+      fireEvent(dropTargetEls[0], drop());
       expect(cmb.getValue().replace("  ", " ")).toBe("(+ 2 1 3)");
     });
 
@@ -124,14 +122,14 @@ describe("Drag and drop", () => {
     it('should move an item to the top level when dragged outside a node 8', function() {
       debugLog('################ 8');
       let dragEvent = dragstart();
-      secondArg.element.dispatchEvent(dragEvent);
+      fireEvent(secondArg.element,dragEvent);
       let dropEvent = drop(dragEvent.dataTransfer);
       let nodeEl = cmb.getAst().rootNodes[0].element;
       let wrapperEl = cmb.getWrapperElement();
       // These two show up as undefined in monitor.getClientOffset ?
       dropEvent.pageX = wrapperEl.offsetLeft + wrapperEl.offsetWidth - 10;
       dropEvent.pageY = nodeEl.offsetTop + wrapperEl.offsetHeight - 10;
-      nodeEl.parentElement.dispatchEvent(dropEvent);
+      fireEvent(nodeEl.parentElement,dropEvent);
       expect(cmb.getValue().replace('  ', ' ')).toBe('(+ 1 3) 2');
       debugLog('%%%%%%%%%%%%%%%% 8');
     });
@@ -139,8 +137,8 @@ describe("Drag and drop", () => {
 
     it("should replace a literal that you drag onto 9", () => {
       let dragEvent = dragstart();
-      firstArg.element!.dispatchEvent(dragEvent);
-      secondArg.element!.dispatchEvent(drop());
+      fireEvent(firstArg.element!, dragEvent);
+      fireEvent(secondArg.element!, drop());
       expect(cmb.getValue().replace(/\s+/, " ")).toBe("(+ 1 3)");
     });
 
@@ -152,11 +150,11 @@ describe("Drag and drop", () => {
       debugLog('################ 10');
       let elt1 = firstArg.element;
       let dragEvent = dragstart();
-      elt1.dispatchEvent(dragEvent);
+      fireEvent(elt1,dragEvent);
       dragEvent.dataTransfer = new DataTransfer();
       dragEvent.dataTransfer.setData('text/plain', '5000');
-      elt1.dispatchEvent(dragend());
-      firstArg.element.dispatchEvent(drop(dragEvent.dataTransfer));
+      fireEvent(elt1,dragend());
+      fireEvent(firstArg.element,drop(dragEvent.dataTransfer));
       //expect(cmb.getValue().replace(/\s+/, ' ')).toBe('(+ 5000 2 3)');
       debugLog('%%%%%%%%%%%%%%%% 10');
     });
@@ -173,7 +171,7 @@ describe("Drag and drop", () => {
       let wrapperEl = cmb.getWrapperElement();
       dropEvent.pageX = wrapperEl.offsetLeft + wrapperEl.offsetWidth - 10;
       dropEvent.pageY = nodeEl.offsetTop + wrapperEl.offsetHeight - 10;
-      nodeEl.parentElement.dispatchEvent(dropEvent);
+      fireEvent(nodeEl.parentElement,dropEvent);
       expect(cmb.getValue().replace('  ', ' ')).toBe('(+ 1 2 3)\n5000');
       debugLog('%%%%%%%%%%%%%%%% 11');
     });
@@ -195,8 +193,8 @@ describe("Drag and drop", () => {
       expect(firstRoot.element!.getAttribute("aria-expanded")).toBe("false");
       expect(firstRoot.nid).toBe(0);
       let dragEvent = dragstart();
-      firstRoot.element!.dispatchEvent(dragEvent); // drag to the last droptarget
-      lastDropTarget.dispatchEvent(drop());
+      fireEvent(firstRoot.element!, dragEvent); // drag to the last droptarget
+      fireEvent(lastDropTarget, drop());
       await finishRender();
       retrieve();
       let newFirstRoot = cmb.getAst().rootNodes[0] as FunctionApp;
@@ -231,16 +229,16 @@ describe("Drag and drop", () => {
     // TODO(pcardune) reenable
     xit("regression test for unstable block IDs", async () => {
       let dragEvent = dragstart();
-      source.element!.dispatchEvent(dragEvent); // drag to the last droptarget
-      target1.dispatchEvent(drop());
+      fireEvent(source.element!, dragEvent); // drag to the last droptarget
+      fireEvent(target1, drop());
       await finishRender();
     });
 
     // TODO(pcardune) reenable
     xit("regression test for empty identifierLists returning a null location", async () => {
       let dragEvent = dragstart();
-      source.element!.dispatchEvent(dragEvent); // drag to the last droptarget
-      target2.dispatchEvent(drop());
+      fireEvent(source.element!, dragEvent); // drag to the last droptarget
+      fireEvent(target2, drop());
       await finishRender();
     });
   });

--- a/spec/new-blocks-test.ts
+++ b/spec/new-blocks-test.ts
@@ -275,13 +275,13 @@ describe("The CodeMirrorBlocks Class", function () {
         // fails nondeterministically - figure out how to avoid
         // see https://github.com/bootstrapworld/codemirror-blocks/issues/123
         // it('should save whiteSpace on blur', async function() {
-        //   whiteSpaceEl.dispatchEvent(dblclick());
+        //   fireEvent(whiteSpaceEl, dblclick());
         //   await finishRender();
         //   expect(trackSetQuarantine).toHaveBeenCalledWith("", whiteSpaceEl);
         //   let quarantine = trackSetQuarantine.calls.mostRecent().returnValue;
         //   let trackOnBlur = spyOn(quarantine, 'onblur').and.callThrough();
         //   quarantine.appendChild(document.createTextNode('4253'));
-        //   quarantine.dispatchEvent(blur());
+        //   fireEvent(quarantine, blur());
         //   await finishRender();
         //   expect(trackOnBlur).toHaveBeenCalled();
         //   expect(trackSaveEdit).toHaveBeenCalledWith(quarantine);
@@ -294,20 +294,20 @@ describe("The CodeMirrorBlocks Class", function () {
 
         // not sure how to handle trackChange
         // it('should blur whitespace you are editing on enter', async function() {
-        //   whiteSpaceEl.dispatchEvent(dblclick());
+        //   fireEvent(whiteSpaceEl, dblclick());
         //   let quarantine = trackSetQuarantine.calls.mostRecent().returnValue;
         //   await finishRender();
-        //   quarantine.dispatchEvent(keydown(ENTER));
+        //   fireEvent(quarantine, keydown(ENTER));
         //   expect(trackHandleChange).toHaveBeenCalled();
         // });
 
         xdescribe('when "saving" bad whitepspace inputs,', function () {
           // beforeEach(async function () {
-          // whiteSpaceEl.dispatchEvent(dblclick());
+          // fireEvent(whiteSpaceEl, dblclick());
           // await finishRender();
           // quarantine = trackSetQuarantine.calls.mostRecent().returnValue;
           // quarantine.appendChild(document.createTextNode('"moo'));
-          // quarantine.dispatchEvent(blur());
+          // fireEvent(quarantine, blur());
           // });
           // fails nondeterministically - figure out how to avoid
           // see https://github.com/bootstrapworld/codemirror-blocks/issues/123

--- a/spec/ui/PrimitiveBlock-test-old.js
+++ b/spec/ui/PrimitiveBlock-test-old.js
@@ -34,7 +34,7 @@ describe("The PrimitiveBlock component,", function () {
     const el = renderedBlockNode.root;
 
     const dragEvent = dragstart();
-    el.firstChild.dispatchEvent(dragEvent);
+    fireEvent(el.firstChild, dragEvent);
     expect(dragEvent.dataTransfer.getData("text/plain")).toBe("some-primitive");
   });
 
@@ -56,7 +56,7 @@ describe("The PrimitiveBlock component,", function () {
     );
     const el = renderedBlockNode.root;
     const dragEvent = dragstart();
-    el.firstChild.dispatchEvent(dragEvent);
+    fireEvent(el.firstChild, dragEvent);
     expect(dragEvent.dataTransfer.getData("text/plain")).toBe("some-primitive");
   });
 

--- a/spec/ui/Search-test-old.js
+++ b/spec/ui/Search-test-old.js
@@ -31,16 +31,16 @@ describe("Search component", function () {
       this.match2 = this.blocks.ast.rootNodes[3];
       this.match3 = this.blocks.ast.rootNodes[4].args[0];
 
-      this.nomatch1.el.dispatchEvent(click());
-      this.nomatch1.el.dispatchEvent(keydown(F3));
+      fireEvent(this.nomatch1.el, click());
+      fireEvent(this.nomatch1.el, keydown(F3));
 
       await wait(DELAY);
 
       const searchBox = document.querySelector(".search-input");
       setNativeValue(searchBox, "1");
-      searchBox.dispatchEvent(pureevent("input"));
+      fireEvent(searchBox, pureevent("input"));
       const close = document.querySelector(".wrapper-modal .close");
-      close.dispatchEvent(click());
+      fireEvent(close, click());
 
       await wait(DELAY);
     });
@@ -51,8 +51,8 @@ describe("Search component", function () {
     });
 
     it("should find next match, skipping a non-matching literal", async function () {
-      this.match1.el.dispatchEvent(click());
-      this.match1.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.match1.el, click());
+      fireEvent(this.match1.el, keydown(PGDN));
 
       await wait(DELAY);
 
@@ -61,8 +61,8 @@ describe("Search component", function () {
     });
 
     it("should wrap around to beginning of document for find-next", async function () {
-      this.match3.el.dispatchEvent(click());
-      this.match3.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.match3.el, click());
+      fireEvent(this.match3.el, keydown(PGDN));
 
       await wait(DELAY);
 
@@ -71,8 +71,8 @@ describe("Search component", function () {
     });
 
     it("should wrap around to end of document for find-previous", async function () {
-      this.match1.el.dispatchEvent(click());
-      this.match1.el.dispatchEvent(keydown(PGUP));
+      fireEvent(this.match1.el, click());
+      fireEvent(this.match1.el, keydown(PGUP));
 
       await wait(DELAY);
 
@@ -92,35 +92,35 @@ describe("Search component", function () {
       this.Hello = this.blocks.ast.rootNodes[0].args[3].func;
       this.lll = this.blocks.ast.rootNodes[0].args[5].func;
 
-      this.hello.el.dispatchEvent(click());
+      fireEvent(this.hello.el, click());
     });
 
     it("should be case insensitive by default", async function () {
-      this.hello.el.dispatchEvent(keydown(F3));
+      fireEvent(this.hello.el, keydown(F3));
 
       await wait(DELAY);
 
       const searchBox = document.querySelector(".search-input");
       setNativeValue(searchBox, "hell");
-      searchBox.dispatchEvent(pureevent("input"));
+      fireEvent(searchBox, pureevent("input"));
       const close = document.querySelector(".wrapper-modal .close");
-      close.dispatchEvent(click());
+      fireEvent(close, click());
 
       await wait(DELAY);
 
-      this.hello.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.hello.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.hell);
       expect(document.activeElement).toBe(this.hell.el);
-      this.hell.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.hell.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.Hello);
       expect(document.activeElement).toBe(this.Hello.el);
-      this.Hello.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.Hello.el, keydown(PGDN));
 
       await wait(DELAY);
 
@@ -129,29 +129,29 @@ describe("Search component", function () {
     });
 
     it("should be able to use case sensitive mode", async function () {
-      this.hello.el.dispatchEvent(keydown(F3));
+      fireEvent(this.hello.el, keydown(F3));
 
       await wait(DELAY);
 
       const ignoreCase = document.querySelector('input[name="isIgnoreCase"]');
-      ignoreCase.dispatchEvent(click());
+      fireEvent(ignoreCase, click());
 
       const searchBox = document.querySelector(".search-input");
       setNativeValue(searchBox, "hell");
-      searchBox.dispatchEvent(pureevent("input"));
+      fireEvent(searchBox, pureevent("input"));
 
       const close = document.querySelector(".wrapper-modal .close");
-      close.dispatchEvent(click());
+      fireEvent(close, click());
 
       await wait(DELAY);
 
-      this.hello.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.hello.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.hell);
       expect(document.activeElement).toBe(this.hell.el);
-      this.hell.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.hell.el, keydown(PGDN));
 
       await wait(DELAY);
 
@@ -160,29 +160,29 @@ describe("Search component", function () {
     });
 
     it("should be able to use regex mode", async function () {
-      this.hello.el.dispatchEvent(keydown(F3));
+      fireEvent(this.hello.el, keydown(F3));
 
       await wait(DELAY);
 
       const ignoreCase = document.querySelector('input[name="isRegex"]');
-      ignoreCase.dispatchEvent(click());
+      fireEvent(ignoreCase, click());
 
       const searchBox = document.querySelector(".search-input");
       setNativeValue(searchBox, "ll[ol]");
-      searchBox.dispatchEvent(pureevent("input"));
+      fireEvent(searchBox, pureevent("input"));
 
       const close = document.querySelector(".wrapper-modal .close");
-      close.dispatchEvent(click());
+      fireEvent(close, click());
 
       await wait(DELAY);
 
-      this.hello.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.hello.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.Hello);
       expect(document.activeElement).toBe(this.Hello.el);
-      this.Hello.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.Hello.el, keydown(PGDN));
 
       await wait(DELAY);
 
@@ -210,23 +210,23 @@ describe("Search component", function () {
       this.eDivide = this.blocks.ast.rootNodes[1].args[1];
       this.eMinus = this.blocks.ast.rootNodes[2];
 
-      this.n1.el.dispatchEvent(click());
-      this.n1.el.dispatchEvent(keydown(F3));
+      fireEvent(this.n1.el, click());
+      fireEvent(this.n1.el, keydown(F3));
 
       await wait(DELAY);
 
       const tab = document.querySelectorAll(".react-tabs li")[1]; // second tab
-      tab.dispatchEvent(click());
+      fireEvent(tab, click());
 
       await wait(DELAY);
 
       // There are two types: expression and literal (alphabetically)
       const selector = document.querySelector('select[name="blockType"]');
       selector.value = "expression";
-      selector.dispatchEvent(pureevent("change"));
+      fireEvent(selector, pureevent("change"));
 
       const close = document.querySelector(".wrapper-modal .close");
-      close.dispatchEvent(click());
+      fireEvent(close, click());
 
       await wait(DELAY);
     });
@@ -237,66 +237,66 @@ describe("Search component", function () {
     });
 
     it("should find expression", async function () {
-      this.n1.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.n1.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.eDivide);
       expect(document.activeElement).toBe(this.eDivide.el);
-      this.eDivide.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.eDivide.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.eMinus);
       expect(document.activeElement).toBe(this.eMinus.el);
-      this.eMinus.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.eMinus.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.ePlus);
       expect(document.activeElement).toBe(this.ePlus.el);
-      this.ePlus.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.ePlus.el, keydown(PGDN));
     });
 
     it("should find literals", async function () {
-      this.n1.el.dispatchEvent(keydown(F3));
+      fireEvent(this.n1.el, keydown(F3));
 
       await wait(DELAY);
 
       const tab = document.querySelectorAll(".react-tabs li")[1]; // second tab
-      tab.dispatchEvent(click());
+      fireEvent(tab, click());
 
       await wait(DELAY);
 
       // There are two types: expression and literal (alphabetically)
       const selector = document.querySelector('select[name="blockType"]');
       selector.value = "literal";
-      selector.dispatchEvent(pureevent("change"));
+      fireEvent(selector, pureevent("change"));
 
       const close = document.querySelector(".wrapper-modal .close");
-      close.dispatchEvent(click());
+      fireEvent(close, click());
 
       await wait(DELAY);
 
-      this.n1.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.n1.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.n2);
       expect(document.activeElement).toBe(this.n2.el);
-      this.n2.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.n2.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.divide);
       expect(document.activeElement).toBe(this.divide.el);
-      this.divide.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.divide.el, keydown(PGDN));
 
       await wait(DELAY);
 
       expect(this.blocks.getActiveNode()).toBe(this.n3);
       expect(document.activeElement).toBe(this.n3.el);
-      this.n3.el.dispatchEvent(keydown(PGDN));
+      fireEvent(this.n3.el, keydown(PGDN));
     });
   });
 });

--- a/spec/undo-redo-test.ts
+++ b/spec/undo-redo-test.ts
@@ -5,7 +5,6 @@ import {
   mac,
   cmd_ctrl,
   teardown,
-  activationSetup,
   mouseDown,
   keyDown,
   insertText,
@@ -14,9 +13,6 @@ import {
 } from "../src/toolkit/test-utils";
 import { API } from "../src/CodeMirrorBlocks";
 import { ASTNode } from "../src/ast";
-import { debugLog } from "../src/utils";
-
-debugLog("Doing undo-redo-test.js");
 
 describe("when testing undo/redo,", () => {
   let cmb!: API;
@@ -87,24 +83,31 @@ describe("when testing undo/redo,", () => {
   });
 
   it("make sure edits can be properly undone/redone from the top level", async () => {
+    // initialize the document
     cmb.setValue(`A\nB\n`);
     cmb.clearHistory();
     await finishRender();
     expect(cmb.historySize()).toEqual({ undo: 0, redo: 0 });
 
+    // change (1): cut first root
     mouseDown(currentFirstRoot()); // focus on the 1st root
     keyDown(" ", {}, currentFirstRoot());
     await finishRender();
-    keyDown("X", cmd_ctrl, currentFirstRoot()); // change (1): cut first root
+    keyDown("X", cmd_ctrl, currentFirstRoot());
     await finishRender();
     expect(cmb.getValue()).toEqual("\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 1, redo: 0 });
+
+    // initiate undo from the top-level
     cmb.setCursor({ line: 1, ch: 0 });
-    undo(); // initiate undo from the top-level
+    undo();
     await finishRender();
     expect(cmb.getValue()).toEqual("A\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 0, redo: 1 });
-    redo(); // initiate redo from the top-level
+
+    // initiate redo from the top-level
+    cmb.setCursor({ line: 1, ch: 0 });
+    redo();
     expect(cmb.getValue()).toEqual("\nB\n");
     expect(cmb.historySize()).toEqual({ undo: 1, redo: 0 });
   });

--- a/src/toolkit/simulate.ts
+++ b/src/toolkit/simulate.ts
@@ -45,7 +45,7 @@ export function paste(
   }
   var pasteEvent = new ClipboardEvent("paste", { clipboardData: dT });
   pasteEvent.clipboardData?.setData("text/plain", pastedString);
-  toElement(node).dispatchEvent(pasteEvent);
+  fireEvent(toElement(node), pasteEvent);
   //userEvent.paste(toElement(node), pastedString);
 }
 export function cut(node: ElementLike = getActiveElementOrThrow()) {
@@ -69,7 +69,7 @@ export function dragstart() {
 }
 
 export function dragover(node: ElementLike = getActiveElementOrThrow()) {
-  toElement(node).dispatchEvent(createBubbledEvent("dragover"));
+  fireEvent(toElement(node), createBubbledEvent("dragover"));
 }
 
 export function mouseenter() {
@@ -85,9 +85,9 @@ export function mouseover() {
 }
 
 export function dragenterSeq(node: ElementLike = getActiveElementOrThrow()) {
-  //toElement(node).dispatchEvent(mouseenter());
-  toElement(node).dispatchEvent(dragenter());
-  toElement(node).dispatchEvent(mouseover());
+  //fireEvent(toElement(node), mouseenter());
+  fireEvent(toElement(node), dragenter());
+  fireEvent(toElement(node), mouseover());
 }
 
 export function dragleave() {
@@ -123,7 +123,7 @@ export function keyDown(
   if (node.nodeName == "TEXTAREA") {
     let event = new CustomKeydownEvent(key);
     Object.assign(event, props);
-    node.dispatchEvent(event);
+    fireEvent(node, event);
   } else {
     fireEvent.keyDown(node, makeKeyEvent(key, props));
   }


### PR DESCRIPTION
All the log spew about not wrapping changes to react components inside of `act(() => { })` statements was because we were calling `dispatchEvent` directly on elements rendered by react, rather than using `fireEvent`. See [act() docs](https://reactjs.org/docs/test-utils.html#act). Because the event handlers on these dom elements were hooked into react components (calling setState and whatnot), it would spew this error.