### PR TITLE
Remove ASTNode.mark in favor of using a context

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -582,13 +582,6 @@ export abstract class ASTNode<
    */
   __alreadyValidated: boolean = false;
 
-  /**
-   * @internal
-   * the CM TextMarker which contains the element representing the node
-   * (only relevant for rootNodes)
-   */
-  mark: BlockNodeMarker;
-
   constructor(from: Pos, to: Pos, type: string, options: Opt) {
     this.from = from;
     this.to = to;

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -13,6 +13,7 @@ import { isDummyPos } from "../utils";
 import { keyDown } from "../keymap";
 import { EditorContext } from "./Context";
 import { useLanguageOrThrow, useSearchOrThrow } from "../hooks";
+import { RootNodeContext } from "../ui/ToplevelBlock";
 
 // TODO(Oak): make sure that all use of node.<something> is valid
 // since it might be cached and outdated
@@ -39,15 +40,14 @@ const Node = ({ expandable = true, ...props }: Props) => {
     }
   );
 
+  const rootNode = useContext(RootNodeContext);
   useEffect(() => {
-    // if its a top level node (ie - it has a CM mark on the node) AND
-    // its isCollapsed property has changed, call mark.changed() to
-    // tell CodeMirror that the widget's height may have changed
-    // TODO(pcardune): Does this logic perhaps belong in ToplevelBlock?
-    if (props.node.mark) {
-      props.node.mark.changed();
-    }
-  }, [stateProps.isCollapsed, props.node.mark]);
+    // Whenever a node gets rerendered because it's collapsed state has changed,
+    // make sure to notifiy
+    // codemirror by calling marker.changed() on the rootNode
+    // marker object, in case the widget's height has changed.
+    rootNode.marker?.changed();
+  }, [stateProps.isCollapsed]);
 
   const [editable, setEditable] = useState(false);
   props.node.isEditable = () => editable;


### PR DESCRIPTION
The logic of calling `marker.changed()` in `Node` was correct, but it's implementation didn't actually match the comment.

The comment said, "if the height of the node changes, then notify codemirror that the marker has changed." Presumably this is because codemirror elides markers that are well outside the visible range to improve performance, and needs to know when their heights change to re-compute a proper scroll bar.

In the previous implementation we only notified codemirror when the toplevel node (the one with the marker) gets collapsed/uncollapsed. But the height of the element actually changes whenever _any node in that tree_ is collapsed/uncollapsed.

With this PR, we notify codemirror when any child is collapsed/uncollapsed, and use a context object to pass down the root level marker object instead of just sticking it on the root ASTNode. This has a nice side effect of cleaning up the ASTNode class a bit more.