### PR TITLE
Fix failing activation tests

### DIFF
--- a/spec/activation-test.ts
+++ b/spec/activation-test.ts
@@ -13,9 +13,6 @@ import {
 import { API } from "../src/CodeMirrorBlocks";
 import { ASTNode } from "../src/ast";
 import { FunctionApp } from "../src/nodes";
-import { debugLog } from "../src/utils";
-
-debugLog("Doing activation-test.js");
 
 const activeAriaId = (cmb: API) =>
   cmb.getScrollerElement().getAttribute("aria-activedescendent");
@@ -62,10 +59,9 @@ describe("when dealing with node activation,", () => {
     expect(cmb.getValue()).toBe("11\n54");
   });
 
-  // TODO(pcardune): fix this test, which is also generating
-  // errors with cyclic data structures...
-  xit("should activate the first node when down is pressed", async () => {
+  it("should activate the first node when down is pressed", async () => {
     mouseDown(literal1.element!);
+    await finishRender();
     keyDown("[", { ctrlKey: true }, literal1.element!); // set cursor to the left
     await finishRender();
     keyDown("ArrowDown");
@@ -78,6 +74,7 @@ describe("when dealing with node activation,", () => {
 
   it("should activate the next node when down is pressed", async () => {
     keyDown("ArrowDown");
+    await finishRender();
     keyDown("ArrowDown");
     await finishRender();
     expect(cmb.getFocusedNode()).not.toBe(literal1);


### PR DESCRIPTION
Having to add all the `await finishRender()` calls is quite annoying and error prone. One way we won't have to. I think a bunch of these zero delay async calls are not actually needed. Slowly I'll remove them. Until then here is a test fix.