### PR TITLE
Move api mutation out of react components

### DIFF
--- a/src/CodeMirrorBlocks.tsx
+++ b/src/CodeMirrorBlocks.tsx
@@ -80,13 +80,13 @@ export type Language = {
 };
 
 type Props = {
-  api: any;
+  onMount: (api: API) => void;
   options?: Options;
   language: Language;
   codemirrorOptions?: CodeMirror.EditorConfiguration;
 };
 export const CodeMirrorBlocksComponent = ({
-  api,
+  onMount,
   options = {},
   language,
   codemirrorOptions = {},
@@ -96,7 +96,7 @@ export const CodeMirrorBlocksComponent = ({
       <ToggleEditor
         language={language}
         initialCode={options.value ?? ""}
-        api={api}
+        onMount={onMount}
         options={options}
         codemirrorOptions={codemirrorOptions}
       />
@@ -121,11 +121,11 @@ function CodeMirrorBlocks(
   language: Language,
   codemirrorOptions: CodeMirror.EditorConfiguration = {}
 ): API {
-  let api: API = {} as any;
+  let apiBox: API = {} as any;
   ReactDOM.render(
     <CodeMirrorBlocksComponent
       language={language}
-      api={api}
+      onMount={(api) => Object.assign(apiBox, api)}
       options={options}
       codemirrorOptions={codemirrorOptions}
     />,
@@ -135,7 +135,7 @@ function CodeMirrorBlocks(
   // Used to hide the application from screen readers while a modal
   // is open.
   Modal.setAppElement(container);
-  return api;
+  return apiBox;
 }
 
 export {

--- a/src/toolkit/test-utils.tsx
+++ b/src/toolkit/test-utils.tsx
@@ -77,7 +77,9 @@ export async function mountCMB(language: Language): Promise<API> {
   render(
     <CodeMirrorBlocksComponent
       language={language}
-      api={cmb}
+      onMount={(newAPI) => {
+        Object.assign(cmb, newAPI);
+      }}
       options={{ collapseAll: false, value: "", incrementalRendering: false }}
       codemirrorOptions={codemirrorOptions}
     />,

--- a/src/ui/BlockEditor.tsx
+++ b/src/ui/BlockEditor.tsx
@@ -148,7 +148,6 @@ export type BlockEditorProps = typeof BlockEditor.defaultProps &
     search?: Search;
     onBeforeChange?: IUnControlledCodeMirror["onBeforeChange"];
     onMount: (editor: CodeMirrorFacade, api: BuiltAPI, passedAST: AST) => void;
-    api?: API;
     passedAST: AST;
     ast: AST;
   };
@@ -310,7 +309,7 @@ class BlockEditor extends Component<BlockEditorProps> {
    */
   private handleEditorDidMount = (editor: CodeMirrorFacade) => {
     this.setState({ editor });
-    const { passedAST: ast, setAST, search, options, onMount } = this.props;
+    const { passedAST: ast, setAST, search, options } = this.props;
     editor.codemirror.on("beforeChange", (ed, change) =>
       this.handleBeforeChange(editor, change)
     );
@@ -337,7 +336,7 @@ class BlockEditor extends Component<BlockEditorProps> {
     wrapper.setAttribute("tabIndex", "-1");
 
     // pass the block-mode CM editor, API, and current AST
-    onMount(editor, this.buildAPI(editor), ast);
+    this.props.onMount(editor, this.buildAPI(editor), ast);
   };
 
   /**

--- a/src/ui/TextEditor.tsx
+++ b/src/ui/TextEditor.tsx
@@ -28,7 +28,6 @@ type Props = {
   value: string;
   onBeforeChange?: IUnControlledCodeMirror["onBeforeChange"];
   onMount: (ed: CodeMirrorFacade, api: API, ast: AST | undefined) => void;
-  api?: API;
   passedAST?: AST;
 };
 


### PR DESCRIPTION
Rather than pass in an empty api object that gets filled and mutated by the react components, instead the react components just use their existing `onMount()` property to pass a newly constructed api object up the component tree. Whatever code is responsible for rendering the top react component can decide for itself how to use the objects that it gets back. React components really shouldn't be mutating state that they don't own, and now they don't! 