### PR TITLE
Move all ASTNode subclass spec fields into fields property

### DIFF
--- a/packages/codemirror-blocks/spec/activation-test.ts
+++ b/packages/codemirror-blocks/spec/activation-test.ts
@@ -209,10 +209,10 @@ describe("tree navigation", () => {
     firstRoot = ast.rootNodes[0] as FunctionApp;
     secondRoot = ast.rootNodes[1];
     thirdRoot = ast.rootNodes[2] as FunctionApp;
-    funcSymbol = firstRoot.func;
-    thirdArg = firstRoot.args[2];
-    nestedExpr = thirdRoot.args[1] as FunctionApp;
-    lastNode = nestedExpr.args[1];
+    funcSymbol = firstRoot.fields.func;
+    thirdArg = firstRoot.fields.args[2];
+    nestedExpr = thirdRoot.fields.args[1] as FunctionApp;
+    lastNode = nestedExpr.fields.args[1];
     await finishRender();
   });
 
@@ -240,19 +240,19 @@ describe("tree navigation", () => {
   it("down-arrow should navigate to the next sibling, but not beyond the tree", async () => {
     mouseDown(firstRoot);
     keyDown("ArrowLeft", {}, firstRoot); // collapse that root
-    mouseDown(nestedExpr.args[0]);
+    mouseDown(nestedExpr.fields.args[0]);
     await finishRender();
-    expect(cmb.getFocusedNode()).toBe(nestedExpr.args[0]);
+    expect(cmb.getFocusedNode()).toBe(nestedExpr.fields.args[0]);
 
     keyDown("ArrowDown");
     await finishRender();
-    expect(cmb.getFocusedNode()).toBe(nestedExpr.args[1]);
-    expect(activeAriaId(cmb)).toBe(nestedExpr.args[1].element!.id);
+    expect(cmb.getFocusedNode()).toBe(nestedExpr.fields.args[1]);
+    expect(activeAriaId(cmb)).toBe(nestedExpr.fields.args[1].element!.id);
 
     keyDown("ArrowDown");
     await finishRender();
-    expect(cmb.getFocusedNode()).toBe(nestedExpr.args[1]);
-    expect(activeAriaId(cmb)).toBe(nestedExpr.args[1].element!.id);
+    expect(cmb.getFocusedNode()).toBe(nestedExpr.fields.args[1]);
+    expect(activeAriaId(cmb)).toBe(nestedExpr.fields.args[1].element!.id);
   });
 
   it("left-arrow should collapse a block, if it can be", async () => {
@@ -316,8 +316,8 @@ describe("tree navigation", () => {
   });
 
   it("less-than should activate root without collapsing", async () => {
-    mouseDown(nestedExpr.args[1]);
-    keyDown("<", { shiftKey: true }, nestedExpr.args[1]);
+    mouseDown(nestedExpr.fields.args[1]);
+    keyDown("<", { shiftKey: true }, nestedExpr.fields.args[1]);
     await finishRender();
     expect(thirdRoot.element!.getAttribute("aria-expanded")).toBe("true");
     expect(cmb.getFocusedNode()).toBe(thirdRoot);
@@ -468,27 +468,35 @@ describe("when dealing with node selection, ", () => {
     await finishRender();
     keyDown("ArrowDown");
     await finishRender();
-    keyDown(" ", {}, expr.func);
+    keyDown(" ", {}, expr.fields.func);
     await finishRender();
     expect(expr.element!.getAttribute("aria-selected")).toBe("false");
-    expect(expr.func.element!.getAttribute("aria-selected")).toBe("false");
-    expect(expr.args[0].element!.getAttribute("aria-selected")).toBe("true");
-    expect(expr.args[1].element!.getAttribute("aria-selected")).toBe("true");
-    expect(cmb.getFocusedNode()).toBe(expr.func);
+    expect(expr.fields.func.element!.getAttribute("aria-selected")).toBe(
+      "false"
+    );
+    expect(expr.fields.args[0].element!.getAttribute("aria-selected")).toBe(
+      "true"
+    );
+    expect(expr.fields.args[1].element!.getAttribute("aria-selected")).toBe(
+      "true"
+    );
+    expect(cmb.getFocusedNode()).toBe(expr.fields.func);
     expect(cmb.getSelectedNodes().length).toBe(2);
-    expect(cmb.getSelectedNodes()[0]).toBe(expr.args[0]);
+    expect(cmb.getSelectedNodes()[0]).toBe(expr.fields.args[0]);
   });
 
   it("selecting a child, then parent should select all children as well ", async () => {
-    mouseDown(expr.func);
-    keyDown(" ", {}, expr.func);
+    mouseDown(expr.fields.func);
+    keyDown(" ", {}, expr.fields.func);
     await finishRender();
     keyDown("ArrowUp");
     await finishRender();
     keyDown(" ", {}, expr);
     await finishRender();
     expect(expr.element!.getAttribute("aria-selected")).toBe("true");
-    expect(expr.func.element!.getAttribute("aria-selected")).toBe("true");
+    expect(expr.fields.func.element!.getAttribute("aria-selected")).toBe(
+      "true"
+    );
     expect(cmb.getFocusedNode()).toBe(expr);
     expect(cmb.getSelectedNodes().length).toBe(4);
     expect(cmb.getSelectedNodes()[0]).toBe(expr);

--- a/packages/codemirror-blocks/spec/ast-test.ts
+++ b/packages/codemirror-blocks/spec/ast-test.ts
@@ -6,21 +6,21 @@ describe("The Literal Class", () => {
   it("should be constructed with a value and data type", () => {
     const from = { line: 0, ch: 0 };
     const to = { line: 0, ch: 2 };
-    const literal = new Literal(from, to, 11, "number");
+    const literal = new Literal(from, to, "11", "number");
     expect(literal.from).toBe(from);
     expect(literal.to).toBe(to);
-    expect(literal.value).toBe(11);
-    expect(literal.dataType).toBe("number");
+    expect(literal.fields.value).toBe("11");
+    expect(literal.fields.dataType).toBe("number");
     expect(literal.options).toEqual({});
   });
 
   it("should set a default data type of unknown if one isn't provided", () => {
-    const literal = new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, 11);
-    expect(literal.dataType).toBe("unknown");
+    const literal = new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, "11");
+    expect(literal.fields.dataType).toBe("unknown");
   });
 
   it("should only return itself when iterated over", () => {
-    const literal = new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, 11);
+    const literal = new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, "11");
     expect([...literal.descendants()]).toEqual([literal]);
   });
 
@@ -28,7 +28,7 @@ describe("The Literal Class", () => {
     const literal = new Literal(
       { line: 0, ch: 0 },
       { line: 0, ch: 2 },
-      11,
+      "11",
       "number",
       { "aria-label": "11" }
     );
@@ -54,8 +54,8 @@ describe("The Sequence Class", () => {
       "symbol"
     );
     const args1 = [
-      new Literal({ line: 0, ch: 10 }, { line: 0, ch: 11 }, 1),
-      new Literal({ line: 0, ch: 12 }, { line: 0, ch: 13 }, 2),
+      new Literal({ line: 0, ch: 10 }, { line: 0, ch: 11 }, "1"),
+      new Literal({ line: 0, ch: 12 }, { line: 0, ch: 13 }, "2"),
     ];
     expression1 = new FunctionApp(
       { line: 0, ch: 7 },
@@ -73,8 +73,8 @@ describe("The Sequence Class", () => {
       "symbol"
     );
     const args2 = [
-      new Literal({ line: 0, ch: 18 }, { line: 0, ch: 19 }, 2),
-      new Literal({ line: 0, ch: 20 }, { line: 0, ch: 21 }, 3),
+      new Literal({ line: 0, ch: 18 }, { line: 0, ch: 19 }, "2"),
+      new Literal({ line: 0, ch: 20 }, { line: 0, ch: 21 }, "3"),
     ];
     expression2 = new FunctionApp(
       { line: 0, ch: 15 },
@@ -100,8 +100,8 @@ describe("The Sequence Class", () => {
   it("should be constructed with a list of expressions", () => {
     expect(sequence.from).toBe(from);
     expect(sequence.to).toBe(to);
-    expect(sequence.exprs).toBe(exprs);
-    expect(sequence.name).toEqual(name);
+    expect(sequence.fields.exprs).toBe(exprs);
+    expect(sequence.fields.name).toEqual(name);
   });
 
   it("should take an optional options parameter in its constructor", () => {
@@ -120,8 +120,8 @@ describe("The FunctionApp Class", () => {
   beforeEach(() => {
     func = new Literal({ line: 1, ch: 1 }, { line: 1, ch: 2 }, "+", "symbol");
     args = [
-      new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, 11),
-      new Literal({ line: 1, ch: 6 }, { line: 0, ch: 8 }, 22),
+      new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, "11"),
+      new Literal({ line: 1, ch: 6 }, { line: 0, ch: 8 }, "22"),
     ];
     // (+ 11 22)
     expression = new FunctionApp(
@@ -137,14 +137,14 @@ describe("The FunctionApp Class", () => {
       { line: 1, ch: 9 },
       new Literal({ line: 1, ch: 1 }, { line: 1, ch: 2 }, "+", "symbol"),
       [
-        new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, 11),
+        new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, "11"),
         new FunctionApp(
           { line: 1, ch: 0 },
           { line: 1, ch: 9 },
           new Literal({ line: 1, ch: 1 }, { line: 1, ch: 2 }, "-", "symbol"),
           [
-            new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, 15),
-            new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, 35),
+            new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, "15"),
+            new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, "35"),
           ]
         ),
       ]
@@ -154,82 +154,94 @@ describe("The FunctionApp Class", () => {
   });
 
   it("should take a function name and list of args in its constructor", () => {
-    expect(expression.args).toBe(args);
-    expect(expression.func).toBe(func);
+    expect(expression.fields.args).toBe(args);
+    expect(expression.fields.func).toBe(func);
     expect(expression.options).toEqual({ "aria-label": "+ expression" });
   });
 
   it("should return itself and its descendants when iterated over", () => {
     expect([...nestedExpression.descendants()]).toEqual([
       nestedExpression,
-      nestedExpression.func,
-      nestedExpression.args[0],
-      ...nestedExpression.args[1].descendants(),
+      nestedExpression.fields.func,
+      nestedExpression.fields.args[0],
+      ...nestedExpression.fields.args[1].descendants(),
     ]);
   });
 
   it("should have all navigation pointers and aria attributes set", () => {
-    expect(ast.getNodeAfter(expression)).toEqual(expression.func);
-    expect(ast.getNodeParent(expression.func)).toEqual(expression);
-    expect(ast.getNodeAfter(expression.func)).toEqual(expression.args[0]);
-    expect(ast.getNodeParent(expression.args[0])).toEqual(expression);
-    expect(ast.getNodeBefore(expression.args[0])).toEqual(expression.func);
-    expect(ast.getNodeAfter(expression.args[0])).toEqual(expression.args[1]);
-    expect(ast.getNodeParent(expression.args[1])).toEqual(expression);
-    expect(ast.getNodeBefore(expression.args[1])).toEqual(expression.args[0]);
-    expect(ast.getNodeAfter(expression.args[1])).toBeNull();
+    expect(ast.getNodeAfter(expression)).toEqual(expression.fields.func);
+    expect(ast.getNodeParent(expression.fields.func)).toEqual(expression);
+    expect(ast.getNodeAfter(expression.fields.func)).toEqual(
+      expression.fields.args[0]
+    );
+    expect(ast.getNodeParent(expression.fields.args[0])).toEqual(expression);
+    expect(ast.getNodeBefore(expression.fields.args[0])).toEqual(
+      expression.fields.func
+    );
+    expect(ast.getNodeAfter(expression.fields.args[0])).toEqual(
+      expression.fields.args[1]
+    );
+    expect(ast.getNodeParent(expression.fields.args[1])).toEqual(expression);
+    expect(ast.getNodeBefore(expression.fields.args[1])).toEqual(
+      expression.fields.args[0]
+    );
+    expect(ast.getNodeAfter(expression.fields.args[1])).toBeNull();
   });
 });
 
 describe("The AST Class", () => {
   it("should take a set of root nodes in its constructor", () => {
-    const nodes = [new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, 11)];
+    const nodes = [new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, "11")];
     const ast = new AST(nodes);
     expect(ast.rootNodes).toBe(nodes);
   });
 
   it("should add every node to a node map for quick lookup", () => {
     const nodes = [
-      new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, 11),
+      new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, "11"),
       new FunctionApp(
         { line: 1, ch: 0 },
         { line: 1, ch: 9 },
         new Literal({ line: 1, ch: 1 }, { line: 1, ch: 2 }, "+", "symbol"),
         [
-          new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, 11),
-          new Literal({ line: 1, ch: 6 }, { line: 0, ch: 8 }, 22),
+          new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, "11"),
+          new Literal({ line: 1, ch: 6 }, { line: 0, ch: 8 }, "22"),
         ]
       ),
     ] as [Literal, FunctionApp];
     const ast = new AST(nodes);
     expect(ast.getNodeById(nodes[0].id)).toBe(nodes[0]);
     expect(ast.getNodeById(nodes[1].id)).toBe(nodes[1]);
-    expect(ast.getNodeById(nodes[1].args[0].id)).toBe(nodes[1].args[0]);
-    expect(ast.getNodeById(nodes[1].args[1].id)).toBe(nodes[1].args[1]);
+    expect(ast.getNodeById(nodes[1].fields.args[0].id)).toBe(
+      nodes[1].fields.args[0]
+    );
+    expect(ast.getNodeById(nodes[1].fields.args[1].id)).toBe(
+      nodes[1].fields.args[1]
+    );
   });
 
   it("idential subtrees should have the same hash", () => {
     const nodes1 = [
-      new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, 11),
+      new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, "11"),
       new FunctionApp(
         { line: 1, ch: 0 },
         { line: 1, ch: 9 },
         new Literal({ line: 1, ch: 1 }, { line: 1, ch: 2 }, "+", "symbol"),
         [
-          new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, 11),
-          new Literal({ line: 1, ch: 6 }, { line: 1, ch: 8 }, 22),
+          new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, "11"),
+          new Literal({ line: 1, ch: 6 }, { line: 1, ch: 8 }, "22"),
         ]
       ),
     ];
     const nodes2 = [
-      new Literal({ line: 1, ch: 0 }, { line: 1, ch: 2 }, 11),
+      new Literal({ line: 1, ch: 0 }, { line: 1, ch: 2 }, "11"),
       new FunctionApp(
         { line: 2, ch: 0 },
         { line: 2, ch: 9 },
         new Literal({ line: 2, ch: 1 }, { line: 2, ch: 2 }, "+", "symbol"),
         [
-          new Literal({ line: 2, ch: 3 }, { line: 2, ch: 5 }, 11),
-          new Literal({ line: 2, ch: 6 }, { line: 2, ch: 8 }, 22),
+          new Literal({ line: 2, ch: 3 }, { line: 2, ch: 5 }, "11"),
+          new Literal({ line: 2, ch: 6 }, { line: 2, ch: 8 }, "22"),
         ]
       ),
     ];
@@ -240,7 +252,7 @@ describe("The AST Class", () => {
 
   it("idential subtrees with different comments should have different hashes", () => {
     const nodes1 = [
-      new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, 11, "Number", {
+      new Literal({ line: 0, ch: 0 }, { line: 0, ch: 2 }, "11", "Number", {
         comment: new Comment({ line: 0, ch: 4 }, { line: 0, ch: 7 }, "moo"),
       }),
       new FunctionApp(
@@ -248,20 +260,20 @@ describe("The AST Class", () => {
         { line: 1, ch: 9 },
         new Literal({ line: 1, ch: 1 }, { line: 1, ch: 2 }, "+", "symbol"),
         [
-          new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, 11),
-          new Literal({ line: 1, ch: 6 }, { line: 1, ch: 8 }, 22),
+          new Literal({ line: 1, ch: 3 }, { line: 1, ch: 5 }, "11"),
+          new Literal({ line: 1, ch: 6 }, { line: 1, ch: 8 }, "22"),
         ]
       ),
     ];
     const nodes2 = [
-      new Literal({ line: 1, ch: 0 }, { line: 1, ch: 2 }, 11),
+      new Literal({ line: 1, ch: 0 }, { line: 1, ch: 2 }, "11"),
       new FunctionApp(
         { line: 2, ch: 0 },
         { line: 2, ch: 9 },
         new Literal({ line: 2, ch: 1 }, { line: 2, ch: 2 }, "+", "symbol"),
         [
-          new Literal({ line: 2, ch: 3 }, { line: 2, ch: 5 }, 11),
-          new Literal({ line: 2, ch: 6 }, { line: 2, ch: 8 }, 22),
+          new Literal({ line: 2, ch: 3 }, { line: 2, ch: 5 }, "11"),
+          new Literal({ line: 2, ch: 6 }, { line: 2, ch: 8 }, "22"),
         ]
       ),
     ];

--- a/packages/codemirror-blocks/spec/drag-test.ts
+++ b/packages/codemirror-blocks/spec/drag-test.ts
@@ -34,8 +34,8 @@ describe("Drag and drop", () => {
 
     const retrieve = () => {
       const funcApp = cmb.getAst().rootNodes[0] as FunctionApp;
-      firstArg = funcApp.args[0];
-      secondArg = funcApp.args[1];
+      firstArg = funcApp.fields.args[0];
+      secondArg = funcApp.fields.args[1];
       dropTargetEls = cmb
         .getAst()
         .rootNodes[0].element!.querySelectorAll(".blocks-drop-target");
@@ -194,7 +194,7 @@ describe("Drag and drop", () => {
       await finishRender();
       retrieve();
       const newFirstRoot = cmb.getAst().rootNodes[0] as FunctionApp;
-      const newLastChild = newFirstRoot.args[2];
+      const newLastChild = newFirstRoot.fields.args[2];
       expect(cmb.getValue()).toBe("\n(+ 1 2 (collapse me))");
       expect(newFirstRoot.element!.getAttribute("aria-expanded")).toBe("true");
       expect(newLastChild.element!.getAttribute("aria-expanded")).toBe("false");

--- a/packages/codemirror-blocks/spec/focus-test.ts
+++ b/packages/codemirror-blocks/spec/focus-test.ts
@@ -30,10 +30,10 @@ describe("focusing,", () => {
     cmb.setValue("(+ 1 2 3)");
     await finishRender();
     expression = cmb.getAst().rootNodes[0] as FunctionApp;
-    func = expression.func;
-    literal1 = expression.args[0];
-    literal2 = expression.args[1];
-    literal3 = expression.args[2];
+    func = expression.fields.func;
+    literal1 = expression.fields.args[0];
+    literal2 = expression.fields.args[1];
+    literal3 = expression.fields.args[2];
   });
 
   afterEach(teardown);
@@ -102,7 +102,7 @@ describe("focusing,", () => {
     // there's an extra space inserted after 99
     expect(cmb.getValue()).toBe("(+ 1 99 2 3)");
     // TODO(Emmanuel): does getFocusedNode().value always return strings?
-    expect((cmb.getFocusedNode() as Literal).value).toBe("99");
+    expect((cmb.getFocusedNode() as Literal).fields.value).toBe("99");
   });
 
   it("inserting multiple nodes should put focus on the last of the new nodes", async () => {
@@ -115,6 +115,6 @@ describe("focusing,", () => {
     await finishRender();
     expect(cmb.getValue()).toBe("(+ 1 99 88 77 2 3)");
     // TODO(Emmanuel): does getFocusedNode().value always return strings?
-    expect((cmb.getFocusedNode() as Literal).value).toBe("77");
+    expect((cmb.getFocusedNode() as Literal).fields.value).toBe("77");
   });
 });

--- a/packages/codemirror-blocks/spec/markText-test.ts
+++ b/packages/codemirror-blocks/spec/markText-test.ts
@@ -13,7 +13,7 @@ describe("The CodeMirrorBlocks Class", function () {
     let cmb!: API;
     let ast!: AST;
     let literal1!: ASTNode;
-    let expression!: ASTNode & { args: ASTNode[] };
+    let expression!: ASTNode<{ args: ASTNode[] }>;
     beforeEach(async function () {
       cmb = await mountCMB(wescheme);
       cmb.setValue("11\n12\n(+ 3 4 5)");
@@ -21,7 +21,7 @@ describe("The CodeMirrorBlocks Class", function () {
       cmb.getAllMarks().forEach((m) => m.clear());
       ast = cmb.getAst();
       literal1 = ast.rootNodes[0];
-      expression = ast.rootNodes[2] as ASTNode & { args: ASTNode[] };
+      expression = ast.rootNodes[2] as ASTNode<{ args: ASTNode[] }>;
     });
 
     afterEach(function () {
@@ -43,7 +43,7 @@ describe("The CodeMirrorBlocks Class", function () {
     });
 
     it("it should allow you to set a className on a child node", function () {
-      const child = expression.args[2];
+      const child = expression.fields.args[2];
       cmb.markText(child.from, child.to, { className: "error" });
       expect(child.element!.className).toMatch(/error/);
       expect(expression.element!.className).not.toMatch(/error/);

--- a/packages/codemirror-blocks/spec/new-blocks-test.ts
+++ b/packages/codemirror-blocks/spec/new-blocks-test.ts
@@ -128,7 +128,7 @@ describe("The CodeMirrorBlocks Class", function () {
       cmb.setValue("()");
       await finishRender();
       cmb.getValue("(...)"); // blank should be inserted by parser, as '...'
-      const blank = (cmb.getAst().rootNodes[0] as FunctionApp).func;
+      const blank = (cmb.getAst().rootNodes[0] as FunctionApp).fields.func;
       click(blank.element!);
       await finishRender();
       expect(blank.isEditable()).toBe(true);
@@ -194,7 +194,7 @@ describe("The CodeMirrorBlocks Class", function () {
         await finishRender();
         ast = cmb.getAst();
         firstRoot = ast.rootNodes[0];
-        firstArg = (ast.rootNodes[0] as FunctionApp).args[0];
+        firstArg = (ast.rootNodes[0] as FunctionApp).fields.args[0];
         whiteSpaceEl = firstArg.element!.nextElementSibling!;
         blank = ast.rootNodes[1] as FunctionApp;
       });
@@ -230,9 +230,9 @@ describe("The CodeMirrorBlocks Class", function () {
       });
 
       it("Ctrl-] should activate a quarantine in the first arg position", async function () {
-        mouseDown(blank.func.element!);
+        mouseDown(blank.fields.func.element!);
         await finishRender();
-        keyDown("]", { ctrlKey: true }, blank.func.element!);
+        keyDown("]", { ctrlKey: true }, blank.fields.func.element!);
         await finishRender();
         //expect(cmb.setQuarantine).toHaveBeenCalled();
       });

--- a/packages/codemirror-blocks/spec/performEdits-test.ts
+++ b/packages/codemirror-blocks/spec/performEdits-test.ts
@@ -173,6 +173,9 @@ describe("performEdits", () => {
   it("applies edits to the editor and the ast, updating the redux store.", () => {
     const edit = edit_replace("foo", ast, [...ast.rootNodes[1].children()][1]);
     const result = store.dispatch(perform([edit]));
+    if (!result.successful) {
+      throw result.exception;
+    }
     expect(result.successful).toBe(true);
     expect(editor.getValue()).toEqual(`
 (doWhatever)

--- a/packages/codemirror-blocks/src/ast.ts
+++ b/packages/codemirror-blocks/src/ast.ts
@@ -57,6 +57,7 @@ function validateNode(node: ASTNode) {
     "from",
     "to",
     "type",
+    "fields",
     "options",
     "spec",
     "isLockedP",
@@ -528,11 +529,14 @@ export type NodeOptions = {
   "aria-label"?: string;
 };
 
+export type UnknownFields = { [fieldName: string]: unknown };
+export type NodeField = ASTNode | ASTNode[] | unknown;
+export type NodeFields = { [fieldName: string]: NodeField };
 /**
  * Every node in the AST must inherit from the `ASTNode` class, which is used
  * to house some common attributes.
  */
-export abstract class ASTNode<Opt extends NodeOptions = NodeOptions> {
+export abstract class ASTNode<Fields extends NodeFields = UnknownFields> {
   /**
    * @internal
    * Every node must have a Starting and Ending position, represented as
@@ -551,12 +555,14 @@ export abstract class ASTNode<Opt extends NodeOptions = NodeOptions> {
   "aria-setsize": number;
   "aria-posinset": number;
 
+  fields: Fields;
+
   /**
    * @internal
    * the options object always contains the aria-label, but can also
    * include other values
    */
-  options: Opt;
+  options: NodeOptions;
 
   /**
    * @internal
@@ -591,11 +597,18 @@ export abstract class ASTNode<Opt extends NodeOptions = NodeOptions> {
    */
   __alreadyValidated = false;
 
-  constructor(from: Pos, to: Pos, type: string, options: Opt) {
+  constructor(
+    from: Pos,
+    to: Pos,
+    type: string,
+    fields: Fields,
+    options: NodeOptions
+  ) {
     this.from = from;
     this.to = to;
     this.type = type;
     this.options = options;
+    this.fields = fields;
 
     // If this node is commented, give its comment an id based on this node's id.
     if (options.comment) {

--- a/packages/wescheme-blocks/spec/languages/wescheme/WeschemeParser-test.js
+++ b/packages/wescheme-blocks/spec/languages/wescheme/WeschemeParser-test.js
@@ -4,13 +4,12 @@ describe("The WeScheme Parser,", function () {
   beforeEach(function () {
     this.parser = new WeschemeParser();
   });
-
   it("should set the appropriate data type for literals", function () {
-    expect(this.parser.parse("#t")[0].dataType).toBe("boolean");
-    expect(this.parser.parse("1")[0].dataType).toBe("number");
-    expect(this.parser.parse('"hello"')[0].dataType).toBe("string");
-    expect(this.parser.parse("#\\m")[0].dataType).toBe("character");
-    expect(this.parser.parse("foo")[0].dataType).toBe("symbol");
+    expect(this.parser.parse("#t")[0].fields.dataType).toBe("boolean");
+    expect(this.parser.parse("1")[0].fields.dataType).toBe("number");
+    expect(this.parser.parse('"hello"')[0].fields.dataType).toBe("string");
+    expect(this.parser.parse("#\\m")[0].fields.dataType).toBe("character");
+    expect(this.parser.parse("foo")[0].fields.dataType).toBe("symbol");
   });
 
   it("should treat vector literals like expressions", function () {
@@ -37,15 +36,15 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the function symbol to a literal", function () {
-      expect(this.ast[0].func.type).toBe("literal");
-      expect(this.ast[0].func.dataType).toBe("symbol");
+      expect(this.ast[0].fields.func.type).toBe("literal");
+      expect(this.ast[0].fields.func.fields.dataType).toBe("symbol");
     });
 
     it("should support empty expressions by generating a placeholder literal", function () {
       this.ast = this.parser.parse("()");
       expect(this.ast[0].type).toBe("functionApp");
-      expect(this.ast[0].func.value).toBe("...");
-      expect(this.ast[0].func.dataType).toBe("blank");
+      expect(this.ast[0].fields.func.fields.value).toBe("...");
+      expect(this.ast[0].fields.func.fields.dataType).toBe("blank");
     });
   });
 
@@ -60,12 +59,12 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the function symbol to a literal", function () {
-      expect(this.ast[0].func.type).toBe("literal");
-      expect(this.ast[1].func.type).toBe("literal");
-      expect(this.ast[0].func.dataType).toBe("symbol");
-      expect(this.ast[1].func.dataType).toBe("symbol");
-      expect(this.ast[0].func.value).toBe("or");
-      expect(this.ast[1].func.value).toBe("and");
+      expect(this.ast[0].fields.func.type).toBe("literal");
+      expect(this.ast[1].fields.func.type).toBe("literal");
+      expect(this.ast[0].fields.func.fields.dataType).toBe("symbol");
+      expect(this.ast[1].fields.func.fields.dataType).toBe("symbol");
+      expect(this.ast[0].fields.func.fields.value).toBe("or");
+      expect(this.ast[1].fields.func.fields.value).toBe("and");
     });
   });
 
@@ -76,8 +75,8 @@ describe("The WeScheme Parser,", function () {
 
     it("should convert defVar expressions to variableDef", function () {
       expect(this.ast[0].type).toBe("variableDefinition");
-      expect(this.ast[0].name.value).toBe("foo");
-      expect(this.ast[0].body.type).toBe("literal");
+      expect(this.ast[0].fields.name.fields.value).toBe("foo");
+      expect(this.ast[0].fields.body.type).toBe("literal");
     });
   });
 
@@ -92,7 +91,9 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should keep track of the text of the comment", function () {
-      expect(this.ast[0].options.comment.comment).toBe("this is a comment");
+      expect(this.ast[0].options.comment.fields.comment).toBe(
+        "this is a comment"
+      );
     });
   });
 
@@ -106,13 +107,13 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the struct name correctly", function () {
-      expect(this.ast[0].name.value).toBe("3d-point");
+      expect(this.ast[0].fields.name.fields.value).toBe("3d-point");
     });
 
     it("should parse fields correctly", function () {
-      expect(this.ast[0].fields.ids.length).toBe(3);
-      expect(this.ast[0].fields.ids[0].value).toBe("x");
-      expect(this.ast[0].fields.ids[2].value).toBe("z");
+      expect(this.ast[0].fields.fields.fields.ids.length).toBe(3);
+      expect(this.ast[0].fields.fields.fields.ids[0].fields.value).toBe("x");
+      expect(this.ast[0].fields.fields.fields.ids[2].fields.value).toBe("z");
     });
   });
 
@@ -126,16 +127,16 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the function name correctly", function () {
-      expect(this.ast[0].name.value).toBe("add2");
+      expect(this.ast[0].fields.name.fields.value).toBe("add2");
     });
 
     it("should convert the function argument correctly", function () {
-      expect(this.ast[0].params.ids.length).toBe(1);
-      expect(this.ast[0].params.ids[0].value).toBe("x");
+      expect(this.ast[0].fields.params.fields.ids.length).toBe(1);
+      expect(this.ast[0].fields.params.fields.ids[0].fields.value).toBe("x");
     });
 
     it("should convert the function body correctly", function () {
-      expect(this.ast[0].body.type).toBe("functionApp");
+      expect(this.ast[0].fields.body.type).toBe("functionApp");
     });
   });
 
@@ -149,13 +150,13 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the arguments correctly", function () {
-      expect(this.ast[0].args.ids.length).toBe(2);
-      expect(this.ast[0].args.ids[0].value).toBe("x");
-      expect(this.ast[0].args.ids[1].value).toBe("y");
+      expect(this.ast[0].fields.args.fields.ids.length).toBe(2);
+      expect(this.ast[0].fields.args.fields.ids[0].fields.value).toBe("x");
+      expect(this.ast[0].fields.args.fields.ids[1].fields.value).toBe("y");
     });
 
     it("should convert the body correctly", function () {
-      expect(this.ast[0].body.type).toBe("functionApp");
+      expect(this.ast[0].fields.body.type).toBe("functionApp");
     });
   });
 
@@ -174,7 +175,7 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the clauses correctly", function () {
-      const clauses = this.ast[0].clauses;
+      const clauses = this.ast[0].fields.clauses;
       expect(clauses.length).toBe(3);
       expect(clauses[0].type).toBe("condClause");
     });
@@ -199,19 +200,19 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the test expression correctly", function () {
-      expect(this.ast[0].testExpr.type).toBe("functionApp");
+      expect(this.ast[0].fields.testExpr.type).toBe("functionApp");
     });
 
     it("should convert the then expression correctly", function () {
-      expect(this.ast[0].thenExpr.type).toBe("literal");
-      expect(this.ast[0].thenExpr.dataType).toBe("symbol");
-      expect(this.ast[0].thenExpr.value).toBe("x");
+      expect(this.ast[0].fields.thenExpr.type).toBe("literal");
+      expect(this.ast[0].fields.thenExpr.fields.dataType).toBe("symbol");
+      expect(this.ast[0].fields.thenExpr.fields.value).toBe("x");
     });
 
     it("should convert the else expression correctly", function () {
-      expect(this.ast[0].elseExpr.type).toBe("literal");
-      expect(this.ast[0].elseExpr.dataType).toBe("symbol");
-      expect(this.ast[0].elseExpr.value).toBe("y");
+      expect(this.ast[0].fields.elseExpr.type).toBe("literal");
+      expect(this.ast[0].fields.elseExpr.fields.dataType).toBe("symbol");
+      expect(this.ast[0].fields.elseExpr.fields.value).toBe("y");
     });
   });
 
@@ -225,24 +226,26 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should get the correct name of the sequence", function () {
-      expect(this.ast[0].name.value).toBe("begin");
+      expect(this.ast[0].fields.name.fields.value).toBe("begin");
     });
 
     it("should convert the sequence's expressions correctly", function () {
-      expect(this.ast[0].exprs[0].type).toBe("functionApp");
-      expect(this.ast[0].exprs[1].type).toBe("functionApp");
+      expect(this.ast[0].fields.exprs[0].type).toBe("functionApp");
+      expect(this.ast[0].fields.exprs[1].type).toBe("functionApp");
     });
 
     it("should leave the expressions in the order that they appeared in the sequence", function () {
-      expect(this.ast[0].exprs[0].func.value).toBe("-");
-      expect(this.ast[0].exprs[1].func.value).toBe("print");
+      expect(this.ast[0].fields.exprs[0].fields.func.fields.value).toBe("-");
+      expect(this.ast[0].fields.exprs[1].fields.func.fields.value).toBe(
+        "print"
+      );
     });
 
     it("should preserve nested expressions in the sequence", function () {
-      var firstExpression = this.ast[0].exprs[0];
-      expect(firstExpression.func.value).toBe("-");
-      expect(firstExpression.args[0].type).toBe("functionApp");
-      expect(firstExpression.args[1].type).toBe("literal");
+      var firstExpression = this.ast[0].fields.exprs[0];
+      expect(firstExpression.fields.func.fields.value).toBe("-");
+      expect(firstExpression.fields.args[0].type).toBe("functionApp");
+      expect(firstExpression.fields.args[1].type).toBe("literal");
     });
   });
 
@@ -258,7 +261,7 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should get the correct form of the letLikeExpr", function () {
-      expect(this.ast[0].form).toBe("let*");
+      expect(this.ast[0].fields.form).toBe("let*");
     });
 
     it("should get the correct aria-label", function () {
@@ -268,20 +271,32 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the bindings to a sequence, correctly", function () {
-      expect(this.ast[0].bindings.type).toBe("sequence");
-      expect(this.ast[0].bindings.name).toBe("bindings");
-      expect(this.ast[0].bindings.exprs.length).toBe(3);
-      expect(this.ast[0].bindings.exprs[0].type).toBe("variableDefinition");
-      expect(this.ast[0].bindings.exprs[0].name.value).toBe("x");
-      expect(this.ast[0].bindings.exprs[1].type).toBe("variableDefinition");
-      expect(this.ast[0].bindings.exprs[1].name.value).toBe("y");
-      expect(this.ast[0].bindings.exprs[2].type).toBe("variableDefinition");
-      expect(this.ast[0].bindings.exprs[2].name.value).toBe("z");
+      expect(this.ast[0].fields.bindings.type).toBe("sequence");
+      expect(this.ast[0].fields.bindings.fields.name).toBe("bindings");
+      expect(this.ast[0].fields.bindings.fields.exprs.length).toBe(3);
+      expect(this.ast[0].fields.bindings.fields.exprs[0].type).toBe(
+        "variableDefinition"
+      );
+      expect(
+        this.ast[0].fields.bindings.fields.exprs[0].fields.name.fields.value
+      ).toBe("x");
+      expect(this.ast[0].fields.bindings.fields.exprs[1].type).toBe(
+        "variableDefinition"
+      );
+      expect(
+        this.ast[0].fields.bindings.fields.exprs[1].fields.name.fields.value
+      ).toBe("y");
+      expect(this.ast[0].fields.bindings.fields.exprs[2].type).toBe(
+        "variableDefinition"
+      );
+      expect(
+        this.ast[0].fields.bindings.fields.exprs[2].fields.name.fields.value
+      ).toBe("z");
     });
 
     it("should convert the let-body properly", function () {
-      expect(this.ast[0].expr.type).toBe("functionApp");
-      expect(this.ast[0].expr.func.value).toBe("*");
+      expect(this.ast[0].fields.expr.type).toBe("functionApp");
+      expect(this.ast[0].fields.expr.fields.func.fields.value).toBe("*");
     });
   });
 
@@ -295,7 +310,7 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should get the correct form of the WhenUnlessExpr", function () {
-      expect(this.ast[0].form).toBe("when");
+      expect(this.ast[0].fields.form).toBe("when");
     });
 
     it("should get the correct aria-label", function () {
@@ -303,20 +318,20 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should convert the predicate properly", function () {
-      expect(this.ast[0].predicate.type).toBe("functionApp");
-      expect(this.ast[0].predicate.func.value).toBe(">");
+      expect(this.ast[0].fields.predicate.type).toBe("functionApp");
+      expect(this.ast[0].fields.predicate.fields.func.fields.value).toBe(">");
     });
 
     it("should convert the exprs to a sequence, correctly", function () {
-      expect(this.ast[0].exprs.type).toBe("sequence");
-      expect(this.ast[0].exprs.name).toBe("begin");
-      expect(this.ast[0].exprs.exprs.length).toBe(3);
-      expect(this.ast[0].exprs.exprs[0].type).toBe("literal");
-      expect(this.ast[0].exprs.exprs[0].value).toBe("x");
-      expect(this.ast[0].exprs.exprs[1].type).toBe("literal");
-      expect(this.ast[0].exprs.exprs[1].value).toBe("y");
-      expect(this.ast[0].exprs.exprs[2].type).toBe("literal");
-      expect(this.ast[0].exprs.exprs[2].value).toBe("z");
+      expect(this.ast[0].fields.exprs.type).toBe("sequence");
+      expect(this.ast[0].fields.exprs.fields.name).toBe("begin");
+      expect(this.ast[0].fields.exprs.fields.exprs.length).toBe(3);
+      expect(this.ast[0].fields.exprs.fields.exprs[0].type).toBe("literal");
+      expect(this.ast[0].fields.exprs.fields.exprs[0].fields.value).toBe("x");
+      expect(this.ast[0].fields.exprs.fields.exprs[1].type).toBe("literal");
+      expect(this.ast[0].fields.exprs.fields.exprs[1].fields.value).toBe("y");
+      expect(this.ast[0].fields.exprs.fields.exprs[2].type).toBe("literal");
+      expect(this.ast[0].fields.exprs.fields.exprs[2].fields.value).toBe("z");
     });
   });
 
@@ -424,160 +439,160 @@ describe("The WeScheme Parser,", function () {
     it("parse malformed defVar (define a)", function () {
       this.ast = this.parser.parse("(define a)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("define");
-      expect(this.ast[0].elts.length).toBe(2);
-      expect(this.ast[0].elts[1].value).toBe("a");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("define");
+      expect(this.ast[0].fields.elts.length).toBe(2);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
     });
 
     it("parse malformed defVars (define-values a)", function () {
       this.ast = this.parser.parse("(define-values a)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("define-values");
-      expect(this.ast[0].elts.length).toBe(2);
-      expect(this.ast[0].elts[1].value).toBe("a");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("define-values");
+      expect(this.ast[0].fields.elts.length).toBe(2);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
     });
 
     it("parse malformed defFun (define (a)", function () {
       this.ast = this.parser.parse("(define (a))");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("define");
-      expect(this.ast[0].elts.length).toBe(2);
-      expect(this.ast[0].elts[1].type).toBe("functionApp");
-      expect(this.ast[0].elts[1].func.value).toBe("a");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("define");
+      expect(this.ast[0].fields.elts.length).toBe(2);
+      expect(this.ast[0].fields.elts[1].type).toBe("functionApp");
+      expect(this.ast[0].fields.elts[1].fields.func.fields.value).toBe("a");
     });
 
     it("parse malformed defStruct (define-struct a (a b c) d)", function () {
       this.ast = this.parser.parse("(define-struct a (a b c) d)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("define-struct");
-      expect(this.ast[0].elts.length).toBe(4);
-      expect(this.ast[0].elts[1].type).toBe("literal");
-      expect(this.ast[0].elts[2].type).toBe("functionApp");
-      expect(this.ast[0].elts[3].value).toBe("d");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("define-struct");
+      expect(this.ast[0].fields.elts.length).toBe(4);
+      expect(this.ast[0].fields.elts[1].type).toBe("literal");
+      expect(this.ast[0].fields.elts[2].type).toBe("functionApp");
+      expect(this.ast[0].fields.elts[3].fields.value).toBe("d");
     });
 
     it("parse malformed ifExpression (if)", function () {
       this.ast = this.parser.parse("(if)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("if");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("if");
     });
 
     it("parse malformed ifExpression (if a)", function () {
       this.ast = this.parser.parse("(if a)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].type).toBe("literal");
-      expect(this.ast[0].elts[0].value).toBe("if");
-      expect(this.ast[0].elts.length).toBe(2);
-      expect(this.ast[0].elts[1].value).toBe("a");
+      expect(this.ast[0].fields.elts[0].type).toBe("literal");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("if");
+      expect(this.ast[0].fields.elts.length).toBe(2);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
     });
 
     it("parse malformed ifExpression (if a b)", function () {
       this.ast = this.parser.parse("(if a b)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].type).toBe("literal");
-      expect(this.ast[0].elts[0].value).toBe("if");
-      expect(this.ast[0].elts.length).toBe(3);
-      expect(this.ast[0].elts[1].value).toBe("a");
-      expect(this.ast[0].elts[2].value).toBe("b");
+      expect(this.ast[0].fields.elts[0].type).toBe("literal");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("if");
+      expect(this.ast[0].fields.elts.length).toBe(3);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
+      expect(this.ast[0].fields.elts[2].fields.value).toBe("b");
     });
 
     it("parse malformed condExpression (cond)", function () {
       this.ast = this.parser.parse("(cond)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].type).toBe("literal");
-      expect(this.ast[0].elts[0].value).toBe("cond");
+      expect(this.ast[0].fields.elts[0].type).toBe("literal");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("cond");
     });
 
     it("parse malformed condExpression (cond (a))", function () {
       this.ast = this.parser.parse("(cond (a))");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].type).toBe("literal");
-      expect(this.ast[0].elts[0].value).toBe("cond");
-      expect(this.ast[0].elts[1].type).toBe("functionApp");
-      expect(this.ast[0].elts[1].func.value).toBe("a");
+      expect(this.ast[0].fields.elts[0].type).toBe("literal");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("cond");
+      expect(this.ast[0].fields.elts[1].type).toBe("functionApp");
+      expect(this.ast[0].fields.elts[1].fields.func.fields.value).toBe("a");
     });
 
     it("parse malformed andExpression (and)", function () {
       this.ast = this.parser.parse("(and)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("and");
-      expect(this.ast[0].elts.length).toBe(1);
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("and");
+      expect(this.ast[0].fields.elts.length).toBe(1);
     });
 
     it("parse malformed orExpression (or a)", function () {
       this.ast = this.parser.parse("(or a)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].type).toBe("literal");
-      expect(this.ast[0].elts[0].value).toBe("or");
-      expect(this.ast[0].elts.length).toBe(2);
-      expect(this.ast[0].elts[1].value).toBe("a");
+      expect(this.ast[0].fields.elts[0].type).toBe("literal");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("or");
+      expect(this.ast[0].fields.elts.length).toBe(2);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
     });
 
     it("parse malformed lambdaExpression (lambda a b)", function () {
       this.ast = this.parser.parse("(lambda a b)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].type).toBe("literal");
-      expect(this.ast[0].elts[0].value).toBe("lambda");
-      expect(this.ast[0].elts.length).toBe(3);
-      expect(this.ast[0].elts[1].value).toBe("a");
-      expect(this.ast[0].elts[2].value).toBe("b");
+      expect(this.ast[0].fields.elts[0].type).toBe("literal");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("lambda");
+      expect(this.ast[0].fields.elts.length).toBe(3);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
+      expect(this.ast[0].fields.elts[2].fields.value).toBe("b");
     });
 
     it("parse malformed localExpression (local a b)", function () {
       this.ast = this.parser.parse("(local a b)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("local");
-      expect(this.ast[0].elts.length).toBe(3);
-      expect(this.ast[0].elts[1].value).toBe("a");
-      expect(this.ast[0].elts[2].value).toBe("b");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("local");
+      expect(this.ast[0].fields.elts.length).toBe(3);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
+      expect(this.ast[0].fields.elts[2].fields.value).toBe("b");
     });
 
     it("parse malformed letrecExpression (letrec a b)", function () {
       this.ast = this.parser.parse("(letrec a b)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("letrec");
-      expect(this.ast[0].elts.length).toBe(3);
-      expect(this.ast[0].elts[1].value).toBe("a");
-      expect(this.ast[0].elts[2].value).toBe("b");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("letrec");
+      expect(this.ast[0].fields.elts.length).toBe(3);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
+      expect(this.ast[0].fields.elts[2].fields.value).toBe("b");
     });
 
     it("parse malformed letExpression (let a b)", function () {
       this.ast = this.parser.parse("(let a b)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("let");
-      expect(this.ast[0].elts.length).toBe(3);
-      expect(this.ast[0].elts[1].value).toBe("a");
-      expect(this.ast[0].elts[2].value).toBe("b");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("let");
+      expect(this.ast[0].fields.elts.length).toBe(3);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
+      expect(this.ast[0].fields.elts[2].fields.value).toBe("b");
     });
 
     it("parse malformed letStarExpression (let* a b)", function () {
       this.ast = this.parser.parse("(let* a b)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("let*");
-      expect(this.ast[0].elts.length).toBe(3);
-      expect(this.ast[0].elts[1].value).toBe("a");
-      expect(this.ast[0].elts[2].value).toBe("b");
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("let*");
+      expect(this.ast[0].fields.elts.length).toBe(3);
+      expect(this.ast[0].fields.elts[1].fields.value).toBe("a");
+      expect(this.ast[0].fields.elts[2].fields.value).toBe("b");
     });
 
     it("parse malformed beginExpression (begin)", function () {
       this.ast = this.parser.parse("(begin)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("begin");
-      expect(this.ast[0].elts.length).toBe(1);
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("begin");
+      expect(this.ast[0].fields.elts.length).toBe(1);
     });
 
     it("parse malformed requireExpression (requre)", function () {
       this.ast = this.parser.parse("(require)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("require");
-      expect(this.ast[0].elts.length).toBe(1);
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("require");
+      expect(this.ast[0].fields.elts.length).toBe(1);
     });
 
     it("parse malformed else (else)", function () {
       this.ast = this.parser.parse("(else)");
       expect(this.ast[0].type).toBe("unknown");
-      expect(this.ast[0].elts[0].value).toBe("else");
-      expect(this.ast[0].elts.length).toBe(1);
+      expect(this.ast[0].fields.elts[0].fields.value).toBe("else");
+      expect(this.ast[0].fields.elts.length).toBe(1);
     });
   });
 });

--- a/packages/wescheme-blocks/src/languages/wescheme/ast.js
+++ b/packages/wescheme-blocks/src/languages/wescheme/ast.js
@@ -20,16 +20,13 @@ function pluralize(noun, set) {
  */
 export class Sequence extends Nodes.Sequence {
   pretty() {
-    return P.standardSexpr(this.name, this.exprs);
+    return P.standardSexpr(this.fields.name, this.fields.exprs);
   }
 }
 
 export class LetLikeExpr extends ASTNode {
   constructor(from, to, form, bindings, expr, options = {}) {
-    super(from, to, "letLikeExpr", options);
-    this.form = form;
-    this.bindings = bindings;
-    this.expr = expr;
+    super(from, to, "letLikeExpr", { form, bindings, expr }, options);
   }
 
   static spec = Spec.nodeSpec([
@@ -39,20 +36,24 @@ export class LetLikeExpr extends ASTNode {
   ]);
 
   longDescription(_level) {
-    return `a ${this.form} expression with ${pluralize(
+    return `a ${this.fields.form} expression with ${pluralize(
       "binding",
       this.bindings.exprs
     )}`;
   }
 
   pretty() {
-    return P.lambdaLikeSexpr(this.form, P.brackets(this.bindings), this.expr);
+    return P.lambdaLikeSexpr(
+      this.fields.form,
+      P.brackets(this.bindings),
+      this.expr
+    );
   }
 
   render(props) {
     return (
       <Node node={this} {...props}>
-        <span className="blocks-operator">{this.form}</span>
+        <span className="blocks-operator">{this.fields.form}</span>
         {this.bindings.reactElement()}
         {this.expr.reactElement()}
       </Node>
@@ -62,10 +63,7 @@ export class LetLikeExpr extends ASTNode {
 
 export class WhenUnless extends ASTNode {
   constructor(from, to, form, predicate, exprs, options = {}) {
-    super(from, to, "whenUnlessExpr", options);
-    this.form = form;
-    this.predicate = predicate;
-    this.exprs = exprs;
+    super(from, to, "whenUnlessExpr", { form, predicate, exprs }, options);
   }
 
   static spec = Spec.nodeSpec([
@@ -75,21 +73,26 @@ export class WhenUnless extends ASTNode {
   ]);
 
   longDescription(level) {
-    return `a ${this.form} expression: ${this.form} ${this.predicate.describe(
+    return `a ${this.fields.form} expression: ${
+      this.fields.form
+    } ${this.fields.predicate.describe(level)}, ${this.fields.exprs.describe(
       level
-    )}, ${this.exprs.describe(level)}`;
+    )}`;
   }
 
   pretty() {
-    return P.standardSexpr(this.form, [this.predicate, this.exprs]);
+    return P.standardSexpr(this.fields.form, [
+      this.fields.predicate,
+      this.fields.exprs,
+    ]);
   }
 
   render(props) {
     return (
       <Node node={this} {...props}>
-        <span className="blocks-operator">{this.form}</span>
-        {this.predicate.reactElement()}
-        {this.exprs.reactElement()}
+        <span className="blocks-operator">{this.fields.form}</span>
+        {this.fields.predicate.reactElement()}
+        {this.fields.exprs.reactElement()}
       </Node>
     );
   }


### PR DESCRIPTION
I can't remember where I wrote up the problem that this solves in more detail, but the tl;dr is that subclasses of `ASTNode` could not have a spec with a field named "id", "hash", "nid", "element", "level", "from", etc. and we could not add any new properties to `ASTNode` without potentially breaking language modules that happened to use a field with the same name.

This PR moves all fields into a `fields` prop, so the namespaces of fields and ASTNode properties are separate and don't conflict. As an added bonus, ASTNodes can now have better types because ASTNode is generic on the `fields` property.

This also hopefully gets us closer to an API that doesn't involve subclassing.

Since this is a long diff, I'll summarize the changes:

Before:
```ts
export class FunctionApp extends ASTNode {
  func: ASTNode;
  args: ASTNode[];
  constructor(from: Pos, to: Pos, func: ASTNode, args: ASTNode[]) {
    super(from, to, "functionApp");
    this.func = func;
    this.args = args;
  }
  ...
}
const funcCall = new FunctionApp(...);
funcCall.func; // ASTNode
funcCall.args; // ASTNode[]
```

After:

```ts
export class FunctionApp extends ASTNode<{func: ASTNode; args: ASTNode[];}> {
  constructor(from: Pos, to: Pos, func: ASTNode, args: ASTNode[]) {
    super(from, to, "functionApp", {func, args});
  }
  ...
}
const funcCall = new FunctionApp(...);
funcCall.fields.func; // ASTNode
funcCall.fields.args; // ASTNode[]
```

Hat tip to the [Fundamental Theorem of Software Engineering](https://en.wikipedia.org/wiki/Fundamental_theorem_of_software_engineering)