### PR TITLE
Rename properties of NodeOptions to javascript

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -195,7 +195,7 @@ function recursively, which is too much detail.
 
 Instead, you should use `ASTNode.describe(level)`. This will automatically
 use a shorter description for deeply nested nodes. (Specifically, it will use
-`node.options["aria-label"]`.)
+`node.options[ariaLabel]`.)
 
 ### Rendering as Text
 

--- a/packages/codemirror-blocks/spec/ast-test.ts
+++ b/packages/codemirror-blocks/spec/ast-test.ts
@@ -38,9 +38,9 @@ describe("The Literal Class", () => {
       { line: 0, ch: 2 },
       "11",
       "number",
-      { "aria-label": "11" }
+      { ariaLabel: "11" }
     );
-    expect(literal.options).toEqual({ "aria-label": "11" });
+    expect(literal.options).toEqual({ ariaLabel: "11" });
   });
 });
 
@@ -70,7 +70,7 @@ describe("The Sequence Class", () => {
       { line: 0, ch: 14 },
       func1,
       args1,
-      { "aria-label": "+ expression" }
+      { ariaLabel: "+ expression" }
     );
 
     // (- 2 3)
@@ -89,7 +89,7 @@ describe("The Sequence Class", () => {
       { line: 0, ch: 22 },
       func2,
       args2,
-      { "aria-label": "+ expression" }
+      { ariaLabel: "+ expression" }
     );
 
     // (begin (+ 1 2) (- 2 3))
@@ -108,7 +108,7 @@ describe("The Sequence Class", () => {
   });
 
   it("should take an optional options parameter in its constructor", () => {
-    const options = { "aria-label": "sequence" };
+    const options = { ariaLabel: "sequence" };
     const newSequence = Sequence(from, to, exprs, name, options);
     expect(newSequence.options).toEqual(options);
   });
@@ -132,7 +132,7 @@ describe("The FunctionApp Class", () => {
       { line: 1, ch: 9 },
       func,
       args,
-      { "aria-label": "+ expression" }
+      { ariaLabel: "+ expression" }
     );
     // (+ 11 (- 15 35))
     nestedExpression = FunctionApp(
@@ -159,7 +159,7 @@ describe("The FunctionApp Class", () => {
   it("should take a function name and list of args in its constructor", () => {
     expect(expression.fields.args).toBe(args);
     expect(expression.fields.func).toBe(func);
-    expect(expression.options).toEqual({ "aria-label": "+ expression" });
+    expect(expression.options).toEqual({ ariaLabel: "+ expression" });
   });
 
   it("should return itself and its descendants when iterated over", () => {

--- a/packages/codemirror-blocks/src/ast.ts
+++ b/packages/codemirror-blocks/src/ast.ts
@@ -478,11 +478,16 @@ export type Range = {
 
 export type NodeOptions = {
   comment?: ASTNode<{ comment: string }>;
-  "aria-label"?: string;
+
+  /**
+   * The aria label for the node
+   */
+  ariaLabel?: string;
+
   /**
    * A predicate, which prevents the node from being edited
    */
-  isLockedP?: boolean;
+  isNotEditable?: boolean;
 };
 
 export type UnknownFields = { [fieldName: string]: unknown };
@@ -636,7 +641,7 @@ export class ASTNode<Fields extends NodeFields = UnknownFields> {
   }
   // the short description is literally the ARIA label
   shortDescription(): string {
-    return this.options["aria-label"] || "";
+    return this.options["ariaLabel"] || "";
   }
 
   // Pretty-print the node and its children, based on the pp-width

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -54,7 +54,7 @@ const Node = ({ expandable = true, ...props }: Props) => {
 
   const [value, setValue] = useState<string | null | undefined>();
   const editor = useContext(EditorContext);
-  const isLocked = () => Boolean(props.node.options.isLockedP);
+  const isLocked = () => Boolean(props.node.options.isNotEditable);
 
   const dispatch: AppDispatch = useDispatch();
   const store: AppStore = useStore();

--- a/packages/codemirror-blocks/src/languages/wescheme/WeschemeParser.js
+++ b/packages/codemirror-blocks/src/languages/wescheme/WeschemeParser.js
@@ -105,7 +105,7 @@ function parseNode(node, i) {
     let name = parseNode(b.first);
     let val = parseNode(b.second);
     return new VariableDefinition(loc.from, loc.to, name, val, {
-      "aria-label":
+      ariaLabel:
         symbolAria(b.first.val) + " bound to " + val.shortDescription(),
       comment: comment,
     });
@@ -124,7 +124,7 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 1 },
         "...",
         "blank",
-        { "aria-label": "*blank*" }
+        { ariaLabel: "*blank*" }
       );
       // special case for Unit Tests
     } else {
@@ -139,7 +139,7 @@ function parseNode(node, i) {
       }
     }
     return new FunctionApp(from, to, func, children, {
-      "aria-label": label,
+      ariaLabel: label,
       comment: comment,
     });
   } else if (node instanceof structures.andExpr) {
@@ -152,10 +152,10 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 4 },
         "and",
         "symbol",
-        { "aria-label": "and" }
+        { ariaLabel: "and" }
       ),
       node.exprs.map(parseNode).filter((item) => item !== null),
-      { "aria-label": expressionAria("and", node.exprs), comment: comment }
+      { ariaLabel: expressionAria("and", node.exprs), comment: comment }
     );
   } else if (node instanceof structures.orExpr) {
     let comment = node.comment ? makeComment(node) : false;
@@ -167,10 +167,10 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 3 },
         "or",
         "symbol",
-        { "aria-label": "or" }
+        { ariaLabel: "or" }
       ),
       node.exprs.map(parseNode).filter((item) => item !== null),
-      { "aria-label": expressionAria("or", node.exprs), comment: comment }
+      { ariaLabel: expressionAria("or", node.exprs), comment: comment }
     );
   } else if (node instanceof structures.defVar) {
     return new VariableDefinition(
@@ -179,7 +179,7 @@ function parseNode(node, i) {
       parseNode(node.name),
       parseNode(node.expr),
       {
-        "aria-label": symbolAria(node.name.val) + ": value definition",
+        ariaLabel: symbolAria(node.name.val) + ": value definition",
         comment: comment,
       }
     );
@@ -191,7 +191,7 @@ function parseNode(node, i) {
       "fields",
       node.fields.map(parseNode),
       {
-        "aria-label":
+        ariaLabel:
           pluralize("field", node.fields) +
           ": " +
           enumerateIdentifierList(node.fields),
@@ -199,7 +199,7 @@ function parseNode(node, i) {
       }
     );
     return new StructDefinition(from, to, parseNode(node.name), fields, {
-      "aria-label":
+      ariaLabel:
         symbolAria(node.name.val) +
         ": structure definition with " +
         pluralize("field", node.fields) +
@@ -215,7 +215,7 @@ function parseNode(node, i) {
       "arguments:",
       node.args.map(parseNode),
       {
-        "aria-label":
+        ariaLabel:
           pluralize("argument", node.args) +
           ": " +
           enumerateIdentifierList(node.args),
@@ -229,7 +229,7 @@ function parseNode(node, i) {
       args,
       parseNode(node.body),
       {
-        "aria-label":
+        ariaLabel:
           symbolAria(node.name.val) +
           ": function definition with " +
           pluralize("argument", node.args) +
@@ -246,7 +246,7 @@ function parseNode(node, i) {
       "arguments",
       node.args.map(parseNode),
       {
-        "aria-label":
+        ariaLabel:
           pluralize("argument", node.args) +
           ": " +
           enumerateIdentifierList(node.args),
@@ -254,7 +254,7 @@ function parseNode(node, i) {
       }
     );
     return new LambdaExpression(from, to, args, parseNode(node.body), {
-      "aria-label":
+      ariaLabel:
         "anonymous function with " +
         pluralize("argument", node.args) +
         ": " +
@@ -262,7 +262,7 @@ function parseNode(node, i) {
     });
   } else if (node instanceof structures.condExpr) {
     return new CondExpression(from, to, node.clauses.map(parseNode), {
-      "aria-label":
+      ariaLabel:
         "conditional expression with " + pluralize("clause", node.clauses),
     });
   } else if (node instanceof structures.couple) {
@@ -271,7 +271,7 @@ function parseNode(node, i) {
       to,
       parseNode(node.first),
       [parseNode(node.second)],
-      { "aria-label": "condition " + (i + 1) }
+      { ariaLabel: "condition " + (i + 1) }
     );
   } else if (node instanceof structures.ifExpr) {
     let predicate = parseNode(node.predicate);
@@ -280,24 +280,24 @@ function parseNode(node, i) {
     let predLabel = predicate.shortDescription();
     let conLabel = consequence.shortDescription();
     let altLabel = alternative.shortDescription();
-    predicate.options["aria-label"] = "if, " + predLabel;
-    consequence.options["aria-label"] = "then, " + conLabel;
-    alternative.options["aria-label"] = "else, " + altLabel;
+    predicate.options.ariaLabel = "if, " + predLabel;
+    consequence.options.ariaLabel = "then, " + conLabel;
+    alternative.options.ariaLabel = "else, " + altLabel;
     return new IfExpression(from, to, predicate, consequence, alternative, {
-      "aria-label": "if-then-else expression",
+      ariaLabel: "if-then-else expression",
       comment: comment,
     });
   } else if (node instanceof structures.symbolExpr) {
     if (node.val == "...") {
-      return new Blank(from, to, node.val, "symbol", { "aria-label": "blank" });
+      return new Blank(from, to, node.val, "symbol", { ariaLabel: "blank" });
     } else if (["true", "false"].includes(node.val)) {
       return new Literal(from, to, node.val, "boolean", {
-        "aria-label": symbolAria(node.val) + ", a Boolean",
+        ariaLabel: symbolAria(node.val) + ", a Boolean",
         comment: comment,
       });
     } else {
       return new Literal(from, to, node.val, "symbol", {
-        "aria-label": symbolAria(node.val),
+        ariaLabel: symbolAria(node.val),
         comment: comment,
       });
     }
@@ -322,7 +322,7 @@ function parseNode(node, i) {
       )}, a Rational`;
     }
     return new Literal(from, to, value, dataType, {
-      "aria-label": aria,
+      ariaLabel: aria,
       comment: comment,
     });
   } else if (node instanceof structures.comment) {
@@ -336,14 +336,11 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 6 },
         "begin",
         "symbol",
-        { "aria-label": "begin" }
+        { ariaLabel: "begin" }
       ),
       node.exprs.map(parseNode),
       {
-        "aria-label": `sequence containing ${pluralize(
-          "expression",
-          node.exprs
-        )}`,
+        ariaLabel: `sequence containing ${pluralize("expression", node.exprs)}`,
       }
     );
   } else if (
@@ -362,11 +359,11 @@ function parseNode(node, i) {
         loc.to,
         node.bindings.map(parseBinding),
         "bindings",
-        { "aria-label": `${pluralize("binding", node.bindings)}` }
+        { ariaLabel: `${pluralize("binding", node.bindings)}` }
       ),
       parseNode(node.body),
       {
-        "aria-label": `${symbolAria(form)} expression with ${pluralize(
+        ariaLabel: `${symbolAria(form)} expression with ${pluralize(
           "binding",
           node.bindings
         )}`,
@@ -381,9 +378,9 @@ function parseNode(node, i) {
       form,
       parseNode(node.predicate),
       new Sequence(loc.from, loc.to, node.exprs.map(parseNode), "begin", {
-        "aria-label": `${pluralize("expression", node.exprs)}`,
+        ariaLabel: `${pluralize("expression", node.exprs)}`,
       }),
-      { "aria-label": `${symbolAria(form)} expression` }
+      { ariaLabel: `${symbolAria(form)} expression` }
     );
   } else if (node instanceof structures.unsupportedExpr) {
     if (node.val.constructor !== Array) return null;
@@ -393,7 +390,7 @@ function parseNode(node, i) {
       node.val.map(parseNode).filter((item) => item !== null),
       {
         msg: node.errorMsg,
-        "aria-label": "invalid expression",
+        ariaLabel: "invalid expression",
         comment: comment,
       }
     );
@@ -404,7 +401,7 @@ function parseNode(node, i) {
       to,
       parseNode(node.stx),
       [parseNode(node.spec)],
-      { "aria-label": "require " + node.spec.val, comment: comment }
+      { ariaLabel: "require " + node.spec.val, comment: comment }
     );
   }
   return null;
@@ -419,13 +416,13 @@ class WeschemeParser {
       dummyLoc,
       new Literal(dummyLoc, dummyLoc, primitive.name, "symbol"),
       primitive.argumentTypes.map(() => new Blank(dummyLoc, dummyLoc, "")),
-      { "aria-label": primitive.name + " expression" }
+      { ariaLabel: primitive.name + " expression" }
     );
   }
 
   getLiteralNodeForPrimitive(primitive) {
     return new Literal(dummyLoc, dummyLoc, primitive.name, "symbol", {
-      "aria-label": primitive.name,
+      ariaLabel: primitive.name,
     });
   }
 

--- a/packages/codemirror-blocks/src/nodes.tsx
+++ b/packages/codemirror-blocks/src/nodes.tsx
@@ -526,7 +526,7 @@ export function Comment(from: Pos, to: Pos, comment: string, options = {}) {
     to,
     type: "comment",
     fields: { comment },
-    options: { isLockedP: true, ...options },
+    options: { isNotEditable: true, ...options },
     pretty: (node) => {
       const words = node.fields.comment.trim().split(/\s+/);
       const wrapped = P.wrap(words);

--- a/packages/wescheme-blocks/spec/languages/wescheme/WeschemeParser-test.js
+++ b/packages/wescheme-blocks/spec/languages/wescheme/WeschemeParser-test.js
@@ -265,7 +265,7 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should get the correct aria-label", function () {
-      expect(this.ast[0].options["aria-label"]).toBe(
+      expect(this.ast[0].options.ariaLabel).toBe(
         "let-star expression with 3 bindings"
       );
     });
@@ -314,7 +314,7 @@ describe("The WeScheme Parser,", function () {
     });
 
     it("should get the correct aria-label", function () {
-      expect(this.ast[0].options["aria-label"]).toBe("when expression");
+      expect(this.ast[0].options.ariaLabel).toBe("when expression");
     });
 
     it("should convert the predicate properly", function () {
@@ -376,56 +376,54 @@ describe("The WeScheme Parser,", function () {
 
   describe("when setting aria-labels", function () {
     it("should make symbols, and numbers be set to themselves", function () {
-      expect(this.parser.parse("1")[0].options["aria-label"]).toBe("1");
-      expect(this.parser.parse("symbol")[0].options["aria-label"]).toBe(
-        "symbol"
-      );
+      expect(this.parser.parse("1")[0].options.ariaLabel).toBe("1");
+      expect(this.parser.parse("symbol")[0].options.ariaLabel).toBe("symbol");
     });
 
     it("should make boolean values be set to 'true' or 'false'", function () {
-      expect(this.parser.parse("#t")[0].options["aria-label"]).toBe(
+      expect(this.parser.parse("#t")[0].options.ariaLabel).toBe(
         "true, a Boolean"
       );
     });
 
     it("should make string values be set to 'string '+the contents of the string", function () {
-      expect(this.parser.parse('"hello"')[0].options["aria-label"]).toBe(
+      expect(this.parser.parse('"hello"')[0].options.ariaLabel).toBe(
         "hello, a String"
       );
     });
 
     it("should make expression (print 'hello') into 'print expression, 1 input'", function () {
+      expect(this.parser.parse('(print "hello")')[0].options.ariaLabel).toBe(
+        "print expression, 1 input"
+      );
       expect(
-        this.parser.parse('(print "hello")')[0].options["aria-label"]
-      ).toBe("print expression, 1 input");
-      expect(
-        this.parser.parse('(print "hello" "world")')[0].options["aria-label"]
+        this.parser.parse('(print "hello" "world")')[0].options.ariaLabel
       ).toBe("print expression, 2 inputs");
     });
 
     it("should make and/or expressions just like regular expressions", function () {
-      expect(
-        this.parser.parse("(and true true)")[0].options["aria-label"]
-      ).toBe("and expression, 2 inputs");
-      expect(
-        this.parser.parse("(or false true)")[0].options["aria-label"]
-      ).toBe("or expression, 2 inputs");
+      expect(this.parser.parse("(and true true)")[0].options.ariaLabel).toBe(
+        "and expression, 2 inputs"
+      );
+      expect(this.parser.parse("(or false true)")[0].options.ariaLabel).toBe(
+        "or expression, 2 inputs"
+      );
     });
 
     it("should turn symbols into readable words", function () {
-      expect(this.parser.parse("(* 1 2)")[0].options["aria-label"]).toBe(
+      expect(this.parser.parse("(* 1 2)")[0].options.ariaLabel).toBe(
         "multiply expression, 2 inputs"
       );
-      expect(this.parser.parse("(/ 1 2)")[0].options["aria-label"]).toBe(
+      expect(this.parser.parse("(/ 1 2)")[0].options.ariaLabel).toBe(
         "divide expression, 2 inputs"
       );
-      expect(this.parser.parse("(foo? 0)")[0].options["aria-label"]).toBe(
+      expect(this.parser.parse("(foo? 0)")[0].options.ariaLabel).toBe(
         "foo-huh expression, 1 input"
       );
-      expect(this.parser.parse("(set! x 2)")[0].options["aria-label"]).toBe(
+      expect(this.parser.parse("(set! x 2)")[0].options.ariaLabel).toBe(
         "set-bang expression, 2 inputs"
       );
-      expect(this.parser.parse("#(1 2)")[0].options["aria-label"]).toBe(
+      expect(this.parser.parse("#(1 2)")[0].options.ariaLabel).toBe(
         "vector expression, 2 inputs"
       );
     });

--- a/packages/wescheme-blocks/src/languages/wescheme/WeschemeParser.js
+++ b/packages/wescheme-blocks/src/languages/wescheme/WeschemeParser.js
@@ -112,8 +112,7 @@ function parseNode(node, i) {
     let name = parseNode(b.first);
     let val = parseNode(b.second);
     return VariableDefinition(loc.from, loc.to, name, val, {
-      "aria-label":
-        symbolAria(b.first.val) + " bound to " + val.options["aria-label"],
+      ariaLabel: symbolAria(b.first.val) + " bound to " + val.options.ariaLabel,
       comment: comment,
     });
   }
@@ -131,7 +130,7 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 1 },
         "...",
         "blank",
-        { "aria-label": "*blank*" }
+        { ariaLabel: "*blank*" }
       );
       // special case for Unit Tests
     } else {
@@ -146,7 +145,7 @@ function parseNode(node, i) {
       }
     }
     return FunctionApp(from, to, func, children, {
-      "aria-label": label,
+      ariaLabel: label,
       comment: comment,
     });
   } else if (node instanceof structures.andExpr) {
@@ -159,10 +158,10 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 4 },
         "and",
         "symbol",
-        { "aria-label": "and" }
+        { ariaLabel: "and" }
       ),
       node.exprs.map(parseNode).filter((item) => item !== null),
-      { "aria-label": expressionAria("and", node.exprs), comment: comment }
+      { ariaLabel: expressionAria("and", node.exprs), comment: comment }
     );
   } else if (node instanceof structures.orExpr) {
     let comment = node.comment ? makeComment(node) : false;
@@ -174,10 +173,10 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 3 },
         "or",
         "symbol",
-        { "aria-label": "or" }
+        { ariaLabel: "or" }
       ),
       node.exprs.map(parseNode).filter((item) => item !== null),
-      { "aria-label": expressionAria("or", node.exprs), comment: comment }
+      { ariaLabel: expressionAria("or", node.exprs), comment: comment }
     );
   } else if (node instanceof structures.defVar) {
     return VariableDefinition(
@@ -186,7 +185,7 @@ function parseNode(node, i) {
       parseNode(node.name),
       parseNode(node.expr),
       {
-        "aria-label": symbolAria(node.name.val) + ": value definition",
+        ariaLabel: symbolAria(node.name.val) + ": value definition",
         comment: comment,
       }
     );
@@ -198,7 +197,7 @@ function parseNode(node, i) {
       "fields",
       node.fields.map(parseNode),
       {
-        "aria-label":
+        ariaLabel:
           pluralize("field", node.fields) +
           ": " +
           enumerateIdentifierList(node.fields),
@@ -206,7 +205,7 @@ function parseNode(node, i) {
       }
     );
     return StructDefinition(from, to, parseNode(node.name), fields, {
-      "aria-label":
+      ariaLabel:
         symbolAria(node.name.val) +
         ": structure definition with " +
         pluralize("field", node.fields) +
@@ -222,7 +221,7 @@ function parseNode(node, i) {
       "arguments:",
       node.args.map(parseNode),
       {
-        "aria-label":
+        ariaLabel:
           pluralize("argument", node.args) +
           ": " +
           enumerateIdentifierList(node.args),
@@ -236,7 +235,7 @@ function parseNode(node, i) {
       args,
       parseNode(node.body),
       {
-        "aria-label":
+        ariaLabel:
           symbolAria(node.name.val) +
           ": function definition with " +
           pluralize("argument", node.args) +
@@ -253,7 +252,7 @@ function parseNode(node, i) {
       "arguments",
       node.args.map(parseNode),
       {
-        "aria-label":
+        ariaLabel:
           pluralize("argument", node.args) +
           ": " +
           enumerateIdentifierList(node.args),
@@ -261,7 +260,7 @@ function parseNode(node, i) {
       }
     );
     return LambdaExpression(from, to, args, parseNode(node.body), {
-      "aria-label":
+      ariaLabel:
         "anonymous function with " +
         pluralize("argument", node.args) +
         ": " +
@@ -269,7 +268,7 @@ function parseNode(node, i) {
     });
   } else if (node instanceof structures.condExpr) {
     return CondExpression(from, to, node.clauses.map(parseNode), {
-      "aria-label":
+      ariaLabel:
         "conditional expression with " + pluralize("clause", node.clauses),
     });
   } else if (node instanceof structures.couple) {
@@ -278,33 +277,33 @@ function parseNode(node, i) {
       to,
       parseNode(node.first),
       [parseNode(node.second)],
-      { "aria-label": "condition " + (i + 1) }
+      { ariaLabel: "condition " + (i + 1) }
     );
   } else if (node instanceof structures.ifExpr) {
     let predicate = parseNode(node.predicate);
     let consequence = parseNode(node.consequence);
     let alternative = parseNode(node.alternative);
-    let predLabel = predicate.options["aria-label"];
-    let conLabel = consequence.options["aria-label"];
-    let altLabel = alternative.options["aria-label"];
-    predicate.options["aria-label"] = "if, " + predLabel;
-    consequence.options["aria-label"] = "then, " + conLabel;
-    alternative.options["aria-label"] = "else, " + altLabel;
+    let predLabel = predicate.options.ariaLabel;
+    let conLabel = consequence.options.ariaLabel;
+    let altLabel = alternative.options.ariaLabel;
+    predicate.options.ariaLabel = "if, " + predLabel;
+    consequence.options.ariaLabel = "then, " + conLabel;
+    alternative.options.ariaLabel = "else, " + altLabel;
     return IfExpression(from, to, predicate, consequence, alternative, {
-      "aria-label": "if-then-else expression",
+      ariaLabel: "if-then-else expression",
       comment: comment,
     });
   } else if (node instanceof structures.symbolExpr) {
     if (node.val == "...") {
-      return Blank(from, to, node.val, "symbol", { "aria-label": "blank" });
+      return Blank(from, to, node.val, "symbol", { ariaLabel: "blank" });
     } else if (["true", "false"].includes(node.val)) {
       return Literal(from, to, node.val, "boolean", {
-        "aria-label": symbolAria(node.val) + ", a Boolean",
+        ariaLabel: symbolAria(node.val) + ", a Boolean",
         comment: comment,
       });
     } else {
       return Literal(from, to, node.val, "symbol", {
-        "aria-label": symbolAria(node.val),
+        ariaLabel: symbolAria(node.val),
         comment: comment,
       });
     }
@@ -329,7 +328,7 @@ function parseNode(node, i) {
       )}, a Rational`;
     }
     return Literal(from, to, value, dataType, {
-      "aria-label": aria,
+      ariaLabel: aria,
       comment: comment,
     });
   } else if (node instanceof structures.comment) {
@@ -344,13 +343,10 @@ function parseNode(node, i) {
         { line: from.line, ch: from.ch + 6 },
         "begin",
         "symbol",
-        { "aria-label": "begin" }
+        { ariaLabel: "begin" }
       ),
       {
-        "aria-label": `sequence containing ${pluralize(
-          "expression",
-          node.exprs
-        )}`,
+        ariaLabel: `sequence containing ${pluralize("expression", node.exprs)}`,
       }
     );
   } else if (
@@ -365,11 +361,11 @@ function parseNode(node, i) {
       to,
       form,
       Sequence(loc.from, loc.to, node.bindings.map(parseBinding), "bindings", {
-        "aria-label": `${pluralize("binding", node.bindings)}`,
+        ariaLabel: `${pluralize("binding", node.bindings)}`,
       }),
       parseNode(node.body),
       {
-        "aria-label": `${symbolAria(form)} expression with ${pluralize(
+        ariaLabel: `${symbolAria(form)} expression with ${pluralize(
           "binding",
           node.bindings
         )}`,
@@ -384,9 +380,9 @@ function parseNode(node, i) {
       form,
       parseNode(node.predicate),
       Sequence(loc.from, loc.to, node.exprs.map(parseNode), "begin", {
-        "aria-label": `${pluralize("expression", node.exprs)}`,
+        ariaLabel: `${pluralize("expression", node.exprs)}`,
       }),
-      { "aria-label": `${symbolAria(form)} expression` }
+      { ariaLabel: `${symbolAria(form)} expression` }
     );
   } else if (node instanceof structures.unsupportedExpr) {
     if (node.val.constructor !== Array) return null;
@@ -396,14 +392,14 @@ function parseNode(node, i) {
       node.val.map(parseNode).filter((item) => item !== null),
       {
         msg: node.errorMsg,
-        "aria-label": "invalid expression",
+        ariaLabel: "invalid expression",
         comment: comment,
       }
     );
     return unknown;
   } else if (node instanceof structures.requireExpr) {
     return FunctionApp(from, to, parseNode(node.stx), [parseNode(node.spec)], {
-      "aria-label": "require " + node.spec.val,
+      ariaLabel: "require " + node.spec.val,
       comment: comment,
     });
   }
@@ -419,13 +415,13 @@ class WeschemeParser {
       dummyLoc,
       Literal(dummyLoc, dummyLoc, primitive.name, "symbol"),
       primitive.argumentTypes.map(() => Blank(dummyLoc, dummyLoc, "")),
-      { "aria-label": primitive.name + " expression" }
+      { ariaLabel: primitive.name + " expression" }
     );
   }
 
   getLiteralNodeForPrimitive(primitive) {
     return Literal(dummyLoc, dummyLoc, primitive.name, "symbol", {
-      "aria-label": primitive.name,
+      ariaLabel: primitive.name,
     });
   }
 


### PR DESCRIPTION
- `"aria-label"` becomes `ariaLabel` - This matches dom and react apis.
- `isLockedP` becomes `isNotEditable` - no need for an abbreviated suffix indicating how this variable might fit into a formal logic proof, though it did make me feel smart to know what the P stood for.