### PR TITLE
Make value node spec less permissive

### DIFF
--- a/packages/codemirror-blocks/spec/nodeSpec-test.ts
+++ b/packages/codemirror-blocks/spec/nodeSpec-test.ts
@@ -1,0 +1,159 @@
+import { ASTNode, NodeSpec as Spec } from "../src/CodeMirrorBlocks";
+import { Literal } from "../src/nodes";
+import { list, nodeSpec, optional, required, value } from "../src/nodeSpec";
+
+let literal: ASTNode;
+beforeAll(() => {
+  literal = Literal({ line: 0, ch: 0 }, { line: 0, ch: 1 }, "a");
+});
+
+describe("nodeSpec()", () => {
+  let spec!: Spec.NodeSpec;
+  beforeEach(() => {
+    spec = nodeSpec([
+      required("aRequiredField"),
+      optional("anOptionalField"),
+      list("aListField"),
+      value("aValueField"),
+    ]);
+  });
+  describe("NodeSpec.validate()", () => {
+    it("produces error messages NodeSpec object", () => {
+      expect(() =>
+        spec.validate({ type: "my-node", fields: {} })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Expected the required field 'aRequiredField' of 'my-node' to contain an ASTNode."`
+      );
+    });
+  });
+});
+
+describe("required()", () => {
+  it("requires an astnode to be provided", () => {
+    const spec = required("someField");
+    expect(() =>
+      spec.validate({ type: "test-node", fields: {} })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected the required field 'someField' of 'test-node' to contain an ASTNode."`
+    );
+
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: "a non ASTNode value" },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected the required field 'someField' of 'test-node' to contain an ASTNode."`
+    );
+
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: {
+          someField: literal,
+        },
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("optional()", () => {
+  it("requires a the field be an ast node or null", () => {
+    const spec = optional("someField");
+    expect(() =>
+      spec.validate({ type: "test-node", fields: {} })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected the optional field 'someField' of 'test-node' to contain an ASTNode or null."`
+    );
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: "not-an-ast-node" },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected the optional field 'someField' of 'test-node' to contain an ASTNode or null."`
+    );
+    expect(() =>
+      spec.validate({ type: "test-node", fields: { someField: null } })
+    ).not.toThrow();
+    expect(() =>
+      spec.validate({ type: "test-node", fields: { someField: literal } })
+    ).not.toThrow();
+  });
+});
+
+describe("list()", () => {
+  it("requires a list of ast nodes to be provideds", () => {
+    const spec = list("someField");
+    expect(() =>
+      spec.validate({ type: "test-node", fields: {} })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected the listy field 'someField' of 'test-node' to contain an array of ASTNodes."`
+    );
+
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: ["not an ast-node"] },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected the listy field 'someField' of 'test-node' to contain an array of ASTNodes."`
+    );
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: ["not an ast-node", literal] },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected the listy field 'someField' of 'test-node' to contain an array of ASTNodes."`
+    );
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: [literal, literal] },
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("value()", () => {
+  it("requires anything that is not an ASTNode or list of ASTNodes", () => {
+    const spec = value("someField");
+
+    expect(() =>
+      spec.validate({ type: "test-node", fields: { someField: literal } })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected value field 'someField' of 'test-node' to be something other than an ASTNode, Did you mean to use required() or optional() instead?"`
+    );
+
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: ["not-a-node", literal] },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected listy field 'someField' of 'test-node' to contain things other than ASTNodes. Did you mean to use list() instead?"`
+    );
+
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: ["not-a-node", "also-not-a-node"] },
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: {},
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      spec.validate({
+        type: "test-node",
+        fields: { someField: 123 },
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/codemirror-blocks/src/nodeSpec.ts
+++ b/packages/codemirror-blocks/src/nodeSpec.ts
@@ -43,7 +43,8 @@ type NodeLike = {
   type: string;
 };
 
-export class NodeSpec {
+export type { NodeSpec };
+class NodeSpec {
   childSpecs: ChildSpec[];
   constructor(childSpecs: ChildSpec[]) {
     if (!(childSpecs instanceof Array)) {
@@ -206,6 +207,7 @@ export class List extends BaseSpec<ASTNode[]> {
       for (const elem of array) {
         if (!(elem instanceof ASTNode)) {
           valid = false;
+          break;
         }
       }
     } else {
@@ -219,20 +221,19 @@ export class List extends BaseSpec<ASTNode[]> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class Value extends BaseSpec<any> {
+export class Value<V = unknown> extends BaseSpec<V> {
   validate(node: NodeLike) {
     const value = this.getField(node);
     if (value instanceof ASTNode) {
       throw new Error(
-        `Expected value field '${this.fieldName}' of '${node.type}' to be something other than an ASTNode, Did you mean to use Required or Optional instead?`
+        `Expected value field '${this.fieldName}' of '${node.type}' to be something other than an ASTNode, Did you mean to use required() or optional() instead?`
       );
     }
     if (value instanceof Array) {
       for (const elem of value) {
         if (elem instanceof ASTNode) {
           throw new Error(
-            `Expected listy field '${this.fieldName}' of '${node.type}' to contain things other than ASTNodes. Did you mean to use List instead?`
+            `Expected listy field '${this.fieldName}' of '${node.type}' to contain things other than ASTNodes. Did you mean to use list() instead?`
           );
         }
       }

--- a/packages/codemirror-blocks/src/nodeSpec.ts
+++ b/packages/codemirror-blocks/src/nodeSpec.ts
@@ -204,7 +204,9 @@ export class List extends BaseSpec<ASTNode[]> {
     let valid = true;
     if (array instanceof Array) {
       for (const elem of array) {
-        if (!(elem instanceof ASTNode)) valid = false;
+        if (!(elem instanceof ASTNode)) {
+          valid = false;
+        }
       }
     } else {
       valid = false;
@@ -219,7 +221,22 @@ export class List extends BaseSpec<ASTNode[]> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Value extends BaseSpec<any> {
-  validate(_parent: NodeLike) {
-    // Any value is valid, even `undefined`, so there's nothing to check.
+  validate(node: NodeLike) {
+    const value = this.getField(node);
+    if (value instanceof ASTNode) {
+      throw new Error(
+        `Expected value field '${this.fieldName}' of '${node.type}' to be something other than an ASTNode, Did you mean to use Required or Optional instead?`
+      );
+    }
+    if (value instanceof Array) {
+      for (const elem of value) {
+        if (elem instanceof ASTNode) {
+          throw new Error(
+            `Expected listy field '${this.fieldName}' of '${node.type}' to contain things other than ASTNodes. Did you mean to use List instead?`
+          );
+        }
+      }
+    }
+    // Any other value is valid, even `undefined`, so there's nothing else to check.
   }
 }

--- a/packages/codemirror-blocks/src/nodes.tsx
+++ b/packages/codemirror-blocks/src/nodes.tsx
@@ -210,7 +210,7 @@ export function StructDefinition(
         level
       )} to be a structure with ${node.fields.fields.describe(level)}`;
     },
-    spec: Spec.nodeSpec([Spec.value("name"), Spec.required("fields")]),
+    spec: Spec.nodeSpec([Spec.required("name"), Spec.required("fields")]),
   });
 }
 

--- a/packages/wescheme-blocks/spec/languages/wescheme/WeschemeParser-test.js
+++ b/packages/wescheme-blocks/spec/languages/wescheme/WeschemeParser-test.js
@@ -267,7 +267,9 @@ describe("The WeScheme Parser,", function () {
 
     it("should convert the bindings to a sequence, correctly", function () {
       expect(this.ast[0].fields.bindings.type).toBe("sequence");
-      expect(this.ast[0].fields.bindings.fields.name).toBe("bindings");
+      expect(this.ast[0].fields.bindings.fields.name.toString()).toBe(
+        "bindings"
+      );
       expect(this.ast[0].fields.bindings.fields.exprs.length).toBe(3);
       expect(this.ast[0].fields.bindings.fields.exprs[0].type).toBe(
         "variableDefinition"
@@ -325,7 +327,7 @@ describe("The WeScheme Parser,", function () {
 
     it("should convert the exprs to a sequence, correctly", function () {
       expect(this.ast[0].fields.exprs.type).toBe("sequence");
-      expect(this.ast[0].fields.exprs.fields.name).toBe("begin");
+      expect(this.ast[0].fields.exprs.fields.name.toString()).toBe("begin");
       expect(this.ast[0].fields.exprs.fields.exprs.length).toBe(3);
       expect(this.ast[0].fields.exprs.fields.exprs[0].type).toBe("literal");
       expect(this.ast[0].fields.exprs.fields.exprs[0].fields.value).toBe("x");

--- a/packages/wescheme-blocks/src/languages/wescheme/WeschemeParser.js
+++ b/packages/wescheme-blocks/src/languages/wescheme/WeschemeParser.js
@@ -324,9 +324,21 @@ function parseNode(node, i) {
       from,
       to,
       form,
-      Sequence(loc.from, loc.to, node.bindings.map(parseBinding), "bindings", {
-        ariaLabel: `${pluralize("binding", node.bindings)}`,
-      }),
+      Sequence(
+        loc.from,
+        loc.to,
+        node.bindings.map(parseBinding),
+        Literal(
+          { line: from.line, ch: from.ch + 1 },
+          { line: from.line, ch: from.ch + 9 },
+          "bindings",
+          "symbol",
+          { ariaLabel: "bindings" }
+        ),
+        {
+          ariaLabel: `${pluralize("binding", node.bindings)}`,
+        }
+      ),
       parseNode(node.body),
       {
         ariaLabel: `${symbolAria(form)} expression with ${pluralize(
@@ -343,9 +355,21 @@ function parseNode(node, i) {
       to,
       form,
       parseNode(node.predicate),
-      Sequence(loc.from, loc.to, node.exprs.map(parseNode), "begin", {
-        ariaLabel: `${pluralize("expression", node.exprs)}`,
-      }),
+      Sequence(
+        loc.from,
+        loc.to,
+        node.exprs.map(parseNode),
+        Literal(
+          { line: from.line, ch: from.ch + 1 },
+          { line: from.line, ch: from.ch + 6 },
+          "begin",
+          "symbol",
+          { ariaLabel: "begin" }
+        ),
+        {
+          ariaLabel: `${pluralize("expression", node.exprs)}`,
+        }
+      ),
       { ariaLabel: `${symbolAria(form)} expression` }
     );
   } else if (node instanceof structures.unsupportedExpr) {

--- a/packages/wescheme-blocks/src/languages/wescheme/ast.tsx
+++ b/packages/wescheme-blocks/src/languages/wescheme/ast.tsx
@@ -34,7 +34,6 @@ export function Sequence(
     options,
     ...Nodes.SequenceProps,
     pretty: (node) => P.standardSexpr(node.fields.name, node.fields.exprs),
-    spec: Spec.nodeSpec([Spec.value("name"), Spec.list("exprs")]),
   });
 }
 


### PR DESCRIPTION
I discovered a regression where editing a single node in the example wasn't working. The regression was introduced with #534 or #535 when we started generating the hashes for a node lazily. The error that came up was something like this:

1. try to generate a hash for an ASTNode using node spec hash iterator
2. try generating a hash for a specific field in the node using `hashObject`
3. try generating a stable string using `objToStableString`

--- BOOM --- `objToStableString` doesn't work on objects with reference cycles in them. It was trying to convert an ASTNode object, which I guess still has internal cycles :cry: despite my attempts to remove them.  (maybe in `element`?)

ASTNode cyclicness aside, it's weird that we would try to use objToStableString to hash an ASTNode, rather than doing what we normally do and just hashing the individual fields of the node. Why were we doing this? Well, because that field was marked as a Value field and not an Optional or Required field in the node spec, but it was being set to a full node and not just some string or number or other opaque value.

To find where the problem was, I updated the validation for `Value` fields to check that they _don't_ contain an `ASTNode` or a list of `ASTNode`. I think this is the correct behavior because if you're passing in a full node into a value field, you probably have a bug in your parser... right? Well, then I found and fixed (what appear to be) the bugs in the wescheme parser.

Does all this sound right to you @schanzer? If so then I will add tests for this PR before merging.