### PR TITLE
Move form based error reporting out of codemirror-blocks

### DIFF
--- a/packages/codemirror-blocks/src/CodeMirrorBlocks.tsx
+++ b/packages/codemirror-blocks/src/CodeMirrorBlocks.tsx
@@ -140,6 +140,7 @@ function CodeMirrorBlocks(
   Modal.setAppElement(container);
   return apiBox;
 }
+export { setLogReporter } from "./utils";
 
 export {
   CodeMirrorBlocks,

--- a/packages/codemirror-blocks/src/edits/performEdits.ts
+++ b/packages/codemirror-blocks/src/edits/performEdits.ts
@@ -15,7 +15,6 @@ import {
   ClonedASTNode,
 } from "./fakeAstEdits";
 import type { AppThunk } from "../state/store";
-import { getReducerActivities } from "../state/reducers";
 import * as selectors from "../state/selectors";
 import { err, ok, Result } from "./result";
 import { CMBEditor, ReadonlyRangedText } from "../editor";
@@ -235,9 +234,9 @@ export const performEdits =
             annt
           )
         );
-        return changeResult;
+        return ok(changeResult);
       } catch (e) {
-        logResults(getReducerActivities(), e);
+        logResults(e);
         return err(e);
       }
     } else {

--- a/packages/codemirror-blocks/src/ui/DragAndDropEditor.tsx
+++ b/packages/codemirror-blocks/src/ui/DragAndDropEditor.tsx
@@ -107,41 +107,6 @@ const DragAndDropEditor = (props: Props) => {
           props.onKeyDown(editorRef.current, e)
         }
       />
-      {/* 
-          Invisible form for error logging
-          NOTE(Emmanuel) we should re-evaluate this when dealing 
-          with pages that have multiple block editors 
-        */}
-      <iframe
-        name="hidden_iframe"
-        id="hidden_iframe"
-        style={{ display: "none" }}
-      ></iframe>
-      <form
-        method="post"
-        action="https://docs.google.com/forms/d/e/1FAIpQLScJMw-00Kl3bxqp9NhCjijn0I8okCtVeX3VrwT7M1uTsYqBkw/formResponse"
-        name="theForm"
-        id="errorLogForm"
-        target="hidden_iframe"
-        style={{ display: "none" }}
-      >
-        <textarea
-          name="entry.1311696515"
-          id="description"
-          defaultValue="Auto-Generated Crash Log"
-        />
-        <textarea
-          name="entry.1568521986"
-          id="history"
-          defaultValue="default_history"
-        />
-        <textarea
-          name="entry.785063835"
-          id="exception"
-          defaultValue="default_exception"
-        />
-        <input type="button" value="Submit" className="submit" />
-      </form>
     </div>
   );
 };

--- a/packages/codemirror-blocks/src/ui/EditorButtons.tsx
+++ b/packages/codemirror-blocks/src/ui/EditorButtons.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { getReducerActivities } from "../state/reducers";
 import { logResults } from "../utils";
 
 type ToggleButtonProps = {
@@ -29,9 +28,8 @@ export const ToggleButton = (props: ToggleButtonProps) => {
 
 export const BugButton = () => {
   const handleBugReport = () => {
-    const history = JSON.stringify(getReducerActivities());
     const description = prompt("Briefly describe what happened");
-    logResults(history, "user-generated bug report", description || undefined);
+    logResults("user-generated bug report", description || undefined);
   };
 
   return (

--- a/packages/wescheme-blocks/src/wescheme.org.js
+++ b/packages/wescheme-blocks/src/wescheme.org.js
@@ -3,10 +3,53 @@
  * It is bundled using the webpack.
  */
 import { WeScheme } from "./index";
-import { CodeMirrorBlocks } from "codemirror-blocks";
+import { CodeMirrorBlocks, setLogReporter } from "codemirror-blocks";
 import "codemirror/lib/codemirror.css";
 import "./less/example.less";
 
+const errorForm = document.createElement("div");
+errorForm.innerHTML = `<iframe
+  name="hidden_iframe"
+  id="hidden_iframe"
+  style={{ display: "none" }}
+></iframe>
+<form
+  method="post"
+  action="https://docs.google.com/forms/d/e/1FAIpQLScJMw-00Kl3bxqp9NhCjijn0I8okCtVeX3VrwT7M1uTsYqBkw/formResponse"
+  name="theForm"
+  id="errorLogForm"
+  target="hidden_iframe"
+  style={{ display: "none" }}
+>
+  <textarea
+    name="entry.1311696515"
+    id="description"
+    defaultValue="Auto-Generated Crash Log"
+  />
+  <textarea
+    name="entry.1568521986"
+    id="history"
+    defaultValue="default_history"
+  />
+  <textarea
+    name="entry.785063835"
+    id="exception"
+    defaultValue="default_exception"
+  />
+  <input type="button" value="Submit" className="submit" />
+</form>`;
+
 export default function WeschemeBlocks(container, options) {
-  return new CodeMirrorBlocks(container, options, WeScheme);
+  if (!document.contains(errorForm)) {
+    document.appendChild(errorForm);
+  }
+
+  setLogReporter((history, exception, description) => {
+    document.getElementById("description").value = description;
+    document.getElementById("history").value = JSON.stringify(history);
+    document.getElementById("exception").value = String(exception);
+    document.getElementById("errorLogForm").submit();
+  });
+
+  return CodeMirrorBlocks(container, options, WeScheme);
 }


### PR DESCRIPTION
Error logging is generally not something a library should be doing, as it's an application concern. That said, libraries can provide hooks to make it easier for an application to log relevant information when errors relating to that library do happen. This PR makes it possible for applications to set a custom log reporter function which codemirror-blocks will use every time `logResults` gets called.

Now the google form submission code, which is specific to wescheme.org, can live outside codemirror-blocks.

There are still problems with this error reporting setup, like:
- the history of actions is shared across all codemirror instances, so if you have two editors on a single page, you won't be able to reconstitute the state of the editor that failed because the actions of both will be intermixed.
- I checked the wescheme.org website, and it already has a form element with the id "errorLogForm", which has a different set of form fields and points to a different url. So the error reporting on wescheme.org is probably already broken and this PR doesn't fix that. Using generic / commonly named element ids in libraries is bad news.