### PR TITLE
Move setFocusedNode call outside setAfterDOMUpdate

### DIFF
--- a/packages/codemirror-blocks/spec/activation-test.ts
+++ b/packages/codemirror-blocks/spec/activation-test.ts
@@ -73,7 +73,7 @@ describe("when dealing with node activation,", () => {
   });
 
   it("should activate the next node when down is pressed", async () => {
-    keyDown("ArrowDown");
+    mouseDown(literal1.element!);
     await finishRender();
     keyDown("ArrowDown");
     await finishRender();

--- a/packages/codemirror-blocks/spec/api-test.ts
+++ b/packages/codemirror-blocks/spec/api-test.ts
@@ -425,7 +425,9 @@ describe("when testing CM apis,", () => {
     );
   });
 
-  it("setCursor should work as-is for text, or activate the containing block", async () => {
+  // TODO(pcardune): reenable or rewrite this test, which was passing by accident
+  // due to activateByNid being async and not waiting for it.
+  xit("setCursor should work as-is for text, or activate the containing block", async () => {
     cmb.setBlockMode(true);
     await finishRender();
     cmb.setCursor({ line: 1, ch: 1 });

--- a/packages/codemirror-blocks/spec/api-test.ts
+++ b/packages/codemirror-blocks/spec/api-test.ts
@@ -425,19 +425,20 @@ describe("when testing CM apis,", () => {
     );
   });
 
-  // TODO(pcardune): reenable or rewrite this test, which was passing by accident
-  // due to activateByNid being async and not waiting for it.
-  xit("setCursor should work as-is for text, or activate the containing block", async () => {
-    cmb.setBlockMode(true);
-    await finishRender();
+  it("setCursor should work as-is for text, or activate the containing block", async () => {
+    // first test setCursor in text mode
     cmb.setCursor({ line: 1, ch: 1 });
     expect(simpleCursor(cmb.getCursor())).toEqual({ line: 1, ch: 1 });
+
+    // now test setCursor in block mode
+    cmb.setBlockMode(true);
+    await finishRender();
+
     expect(currentFocusNId()).toBe(0);
     cmb.setCursor({ line: 0, ch: 1 });
-    expect(currentFocusNId()).toBe(0);
+    expect(cmb.getFocusedNode()!.nid).toBe(1);
     // activating the first block should return a cursor at its end
     expect(simpleCursor(cmb.getCursor())).toEqual({ line: 0, ch: 7 });
-    await finishRender();
   });
 
   it("setSelection", async () => {

--- a/packages/codemirror-blocks/src/state/actions.ts
+++ b/packages/codemirror-blocks/src/state/actions.ts
@@ -276,9 +276,8 @@ export function activateByNid(
       say("Use enter to edit", 1250, true); // wait 1.25s, and allow to be overridden
     }
 
+    dispatch(setFocusedNode(newNode));
     setAfterDOMUpdate(() => {
-      dispatch(setFocusedNode(newNode));
-
       // if this timeout fires after the node has been torn down, don't bother
       if (newNode.element) {
         if (options.allowMove) {

--- a/packages/codemirror-blocks/src/state/actions.ts
+++ b/packages/codemirror-blocks/src/state/actions.ts
@@ -2,7 +2,6 @@ import {
   poscmp,
   srcRangeIncludes,
   warn,
-  setAfterDOMUpdate,
   getTempCM,
   minpos,
   maxpos,
@@ -277,15 +276,12 @@ export function activateByNid(
     }
 
     dispatch(setFocusedNode(newNode));
-    setAfterDOMUpdate(() => {
-      // if this timeout fires after the node has been torn down, don't bother
-      if (newNode.element) {
-        if (options.allowMove) {
-          editor.scrollASTNodeIntoView(newNode);
-        }
-        newNode.element.focus();
+    if (newNode.element) {
+      if (options.allowMove) {
+        editor.scrollASTNodeIntoView(newNode);
       }
-    });
+      newNode.element.focus();
+    }
   };
 }
 


### PR DESCRIPTION
There isn't a good reason AFAICT why activateByNid should be asynchronous. In this PR, I'm going to try to remove the use of `setAfterDOMUpdate()` from `activateByNid()`