### PR TITLE
use one array ref instead of an array of refs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     ],
     "no-undef": 0,
     "react/display-name": 0,
+    "react/prop-types": 0, // handled by typescript
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "@typescript-eslint/explicit-module-boundary-types": 0,

--- a/packages/codemirror-blocks/src/ui/Toolbar.tsx
+++ b/packages/codemirror-blocks/src/ui/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import classNames from "classnames";
 import PrimitiveList from "./PrimitiveList";
 import { Primitive, PrimitiveGroup } from "../parsers/primitives";
@@ -20,7 +20,7 @@ const Toolbar = (props: Props) => {
   const clearSearch = () => setSearch("");
   const changeSearch: React.ChangeEventHandler<HTMLInputElement> = (event) =>
     setSearch(event.target.value);
-  const primitiveListRef = React.createRef<HTMLElement>();
+  const primitiveListRef = useRef<HTMLUListElement>(null);
 
   // Get a flat array of all primitives matching 'search'
   const getPrimitives = () =>


### PR DESCRIPTION
Welp, I thought the only thing that mattered with hooks was having a consistent order in which they were executed. Didn't realize you also had to have a consistent number of hooks called for every render.

Based on that information, here is my updated take on the problem. I don't know why git generates such a huge diff output because I only changed a few lines, which I'll try to highlight.