### PR TITLE
update/remove outdated wescheme-blocks dependencies (fixes #510)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1589,25 +1589,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/@babel/polyfill/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
-      "hasInstallScript": true
-    },
     "node_modules/@babel/preset-env": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.0.tgz",
@@ -4234,36 +4215,6 @@
       },
       "engines": {
         "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/babel-jest": {
@@ -14077,12 +14028,11 @@
         "codemirror-blocks": "*"
       },
       "devDependencies": {
-        "@babel/polyfill": "^7.12.1",
+        "@babel/eslint-parser": "^7.16.0",
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-react": "^7.14.5",
         "@bootstrapworld/cmb-toolkit": "*",
         "@testing-library/react": "^12.0.0",
-        "babel-eslint": "^10.1.0",
         "eslint-plugin-react": "^7.24.0",
         "webpack-cli": "^4.9.1"
       },
@@ -15145,24 +15095,6 @@
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-          "dev": true
-        }
       }
     },
     "@babel/preset-env": {
@@ -17300,28 +17232,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
     },
     "babel-jest": {
       "version": "27.3.1",
@@ -24353,12 +24263,11 @@
     "wescheme-blocks": {
       "version": "file:packages/wescheme-blocks",
       "requires": {
-        "@babel/polyfill": "^7.12.1",
+        "@babel/eslint-parser": "^7.16.0",
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-react": "^7.14.5",
         "@bootstrapworld/cmb-toolkit": "*",
         "@testing-library/react": "^12.0.0",
-        "babel-eslint": "^10.1.0",
         "codemirror-blocks": "*",
         "eslint-plugin-react": "^7.24.0",
         "webpack-cli": "^4.9.1"

--- a/packages/wescheme-blocks/package.json
+++ b/packages/wescheme-blocks/package.json
@@ -12,12 +12,11 @@
     "codemirror-blocks": "*"
   },
   "devDependencies": {
-    "@babel/polyfill": "^7.12.1",
+    "@babel/eslint-parser": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-react": "^7.14.5",
     "@bootstrapworld/cmb-toolkit": "*",
     "@testing-library/react": "^12.0.0",
-    "babel-eslint": "^10.1.0",
     "eslint-plugin-react": "^7.24.0",
     "webpack-cli": "^4.9.1"
   },


### PR DESCRIPTION
@pcardune I've removed/updated the two packages in wescheme-blocks that were deprecated (polyfill and babel-eslint), and the other warnings are no longer present (I think we've updated webpack-dev-server in the meantime). 