### PR TITLE
Remove copy() exception

### DIFF
--- a/packages/codemirror-blocks/src/copypaste.ts
+++ b/packages/codemirror-blocks/src/copypaste.ts
@@ -43,6 +43,9 @@ function copyToClipboard(text: string) {
 
 /**
  * Copy the given nodes onto the clipboard.
+ * This function is called from keymap.tsx and PrimitiveList.tsx
+ * In both places, the call site checks to ensure the copy
+ * event is fired when a DOM node is active.
  */
 export function copy(nodes: ASTNode[], editWord?: string) {
   const previouslyFocusedElement = document.activeElement;
@@ -67,9 +70,5 @@ export function copy(nodes: ASTNode[], editWord?: string) {
   }
   // do the actual copy, then restore focus
   copyToClipboard(text);
-  if (previouslyFocusedElement) {
-    (previouslyFocusedElement as HTMLElement).focus();
-  } else {
-    throw "copy was initiated, but no node was focused";
-  }
+  (previouslyFocusedElement as HTMLElement).focus();
 }

--- a/packages/codemirror-blocks/src/ui/PrimitiveList.tsx
+++ b/packages/codemirror-blocks/src/ui/PrimitiveList.tsx
@@ -18,7 +18,6 @@ type BasePrimitiveProps = {
   onFocus: (e: React.FocusEvent) => void;
 };
 
-// @pcardune - I still needed to cast the ref here, in order to satisfy TS
 export const Primitive = React.forwardRef<HTMLElement, BasePrimitiveProps>(
   (props, ref) => {
     const { primitive, className, onFocus } = props;


### PR DESCRIPTION
Both call sites ensure that there's an active node, so there's no need to check if a node is active (or throw an exception if it's not). I've added a comment to document this.