### PR TITLE
fix wescheme.org build and add source maps

### DIFF
--- a/packages/wescheme-blocks/src/wescheme.org.js
+++ b/packages/wescheme-blocks/src/wescheme.org.js
@@ -41,7 +41,7 @@ errorForm.innerHTML = `<iframe
 
 export default function WeschemeBlocks(container, options) {
   if (!document.contains(errorForm)) {
-    document.appendChild(errorForm);
+    document.body.appendChild(errorForm);
   }
 
   setLogReporter((history, exception, description) => {

--- a/packages/wescheme-blocks/webpack.config.js
+++ b/packages/wescheme-blocks/webpack.config.js
@@ -32,6 +32,7 @@ const bundleConfig = {
       export: "default",
     },
   },
+  devtool: "source-map",
 };
 
 // TODO(pcardune): figure out what needs to be part of the bundle


### PR DESCRIPTION
I just deployed a new build for https://blocks-dot-wescheme-hrd-2.appspot.com/openEditor and noticed that it was broken with the error:
```
Uncaught DOMException: Failed to execute 'appendChild' on 'Node': Only one element on document allowed.
```

I think this is the right fix, but I couldn't get a local version of wescheme running to test it. Kept getting the following error despite following the README instructions:

```
Buildfile: /home/pcardune/programming/bootstrapworld/wescheme/build.xml

copyjars:

BUILD FAILED
/home/pcardune/programming/bootstrapworld/wescheme/build.xml:28: /home/pcardune/programming/bootstrapworld/wescheme/lib/google-oauth-java-client/libs does not exist.
```