### PR TITLE
Make more ASTNode properties immutable/readonly

### DIFF
--- a/packages/codemirror-blocks/src/ast.ts
+++ b/packages/codemirror-blocks/src/ast.ts
@@ -550,13 +550,7 @@ export interface NodeForSpec<Spec extends NodeSpec = NodeSpec> {
   pretty: () => P.Doc;
   spec: Spec;
 
-  element: HTMLElement | null;
-
-  /**
-   * @internal
-   * Used for unit testing only
-   */
-  isEditable?: () => boolean;
+  readonly element: HTMLElement | null;
 
   readonly _pretty: ASTNodeProps["pretty"];
   readonly render: ASTNodeProps["render"];
@@ -573,6 +567,21 @@ export interface NodeForSpec<Spec extends NodeSpec = NodeSpec> {
   srcRange(): { from: Pos; to: Pos };
   reactElement(props?: Record<string, unknown>): React.ReactElement;
 }
+
+/**
+ * @internal
+ *
+ * A mapping from node id to the HTMLElement representation of that node.
+ *
+ * This is more or less equivalent to what you could get with
+ * `document.getElementById()` except that it will still work for
+ * dom elements that are not (yet) in the document because codemirror
+ * has chosen not to render them since they are outside the field of
+ * view.
+ *
+ * This mapping is populated by Node.tsx
+ */
+export const nodeElementMap = new Map<string, HTMLElement>();
 
 /**
  * Every node in the AST must inherit from the `ASTNode` class, which is used
@@ -618,7 +627,9 @@ export class ASTNode<
    * @internal
    * Stores the html element that this ast node was rendered into.
    */
-  element: HTMLElement | null = null;
+  get element(): HTMLElement | null {
+    return nodeElementMap.get(this.id) ?? null;
+  }
 
   readonly _pretty: ASTNodeProps["pretty"];
   readonly render: ASTNodeProps["render"];

--- a/packages/codemirror-blocks/src/ast.ts
+++ b/packages/codemirror-blocks/src/ast.ts
@@ -538,16 +538,16 @@ export type ASTNodeProps<Spec extends NodeSpec = NodeSpec> = {
 export interface NodeForSpec<Spec extends NodeSpec = NodeSpec> {
   readonly from: Pos;
   readonly to: Pos;
-  type: string;
-  id: string;
-  nid: number;
-  level: number;
-  ariaSetSize: number;
-  ariaPosInset: number;
+  readonly type: string;
+  readonly id: string;
+  readonly nid: number;
+  readonly level: number;
+  readonly ariaSetSize: number;
+  readonly ariaPosInset: number;
 
-  fields: FieldsForSpec<Spec>;
+  readonly fields: FieldsForSpec<Spec>;
   readonly options: NodeOptions;
-  pretty: () => P.Doc;
+  pretty(): P.Doc;
   readonly spec: Spec;
 
   readonly element: HTMLElement | null;
@@ -557,7 +557,7 @@ export interface NodeForSpec<Spec extends NodeSpec = NodeSpec> {
   readonly longDescription?: ASTNodeProps["longDescription"];
 
   _hash: number | undefined;
-  hash: number;
+  readonly hash: number;
   _dangerouslySetHash(hash: number): void;
   describe(level: number): string | undefined;
   shortDescription(): string;
@@ -601,14 +601,14 @@ export class ASTNode<
    */
   readonly from: Pos;
   readonly to: Pos;
-  type: string;
+  readonly type: string;
   id = "uninitialized";
   nid = -1;
   level = -1;
   ariaSetSize = -1;
   ariaPosInset = -1;
 
-  fields: Fields;
+  readonly fields: Fields;
 
   /**
    * @internal

--- a/packages/codemirror-blocks/src/ast.ts
+++ b/packages/codemirror-blocks/src/ast.ts
@@ -536,8 +536,8 @@ export type ASTNodeProps<Spec extends NodeSpec = NodeSpec> = {
 // TODO(pcardune): figure out how to get rid of the duplication
 // between this interface, and the ASTNode class definition
 export interface NodeForSpec<Spec extends NodeSpec = NodeSpec> {
-  from: Pos;
-  to: Pos;
+  readonly from: Pos;
+  readonly to: Pos;
   type: string;
   id: string;
   nid: number;
@@ -546,9 +546,9 @@ export interface NodeForSpec<Spec extends NodeSpec = NodeSpec> {
   ariaPosInset: number;
 
   fields: FieldsForSpec<Spec>;
-  options: NodeOptions;
+  readonly options: NodeOptions;
   pretty: () => P.Doc;
-  spec: Spec;
+  readonly spec: Spec;
 
   readonly element: HTMLElement | null;
 
@@ -599,8 +599,8 @@ export class ASTNode<
    * in the tree, hash for quick comparisons, and aria properties for
    * set size and position in set (for screenreaders)
    */
-  from: Pos;
-  to: Pos;
+  readonly from: Pos;
+  readonly to: Pos;
   type: string;
   id = "uninitialized";
   nid = -1;
@@ -615,13 +615,13 @@ export class ASTNode<
    * the options object always contains the aria-label, but can also
    * include other values
    */
-  options: NodeOptions;
+  readonly options: NodeOptions;
 
   /**
    * @internal
    * nodeSpec, which specifies node requirements (see nodeSpec.ts)
    */
-  spec: NodeSpec;
+  readonly spec: NodeSpec;
 
   /**
    * @internal

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { AST, ASTNode } from "../ast";
+import { AST, ASTNode, nodeElementMap } from "../ast";
 import {
   useDropAction,
   activateByNid,
@@ -229,6 +229,17 @@ const Node = ({ expandable = true, ...props }: Props) => {
     }),
   });
 
+  const nodeElementRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (nodeElementRef.current) {
+      nodeElementMap.set(props.node.id, nodeElementRef.current);
+      return () => {
+        nodeElementMap.delete(props.node.id);
+      };
+    }
+  }, [props.node.id]);
+
   if (editable) {
     if (!editor) {
       throw new Error("can't edit nodes before codemirror has mounted");
@@ -261,7 +272,7 @@ const Node = ({ expandable = true, ...props }: Props) => {
       <span
         {...contentEditableProps}
         className={classNames(classes)}
-        ref={(el) => (props.node.element = el)}
+        ref={nodeElementRef}
         role={props.inToolbar ? "listitem" : "treeitem"}
         style={
           {

--- a/packages/codemirror-blocks/src/edits/patchAst.ts
+++ b/packages/codemirror-blocks/src/edits/patchAst.ts
@@ -12,7 +12,6 @@ function copyAllIds(oldTree: ASTNode, newTree: ASTNode) {
       );
     }
     newPtr.value.id = oldPtr.value.id;
-    newPtr.value.element = oldPtr.value.element;
     oldPtr = oldIter.next();
     newPtr = newIter.next();
   }

--- a/packages/codemirror-blocks/src/edits/performEdits.ts
+++ b/packages/codemirror-blocks/src/edits/performEdits.ts
@@ -12,7 +12,6 @@ import {
   FakeAstInsertion,
   FakeAstReplacement,
   cloneNode,
-  ClonedASTNode,
 } from "./fakeAstEdits";
 import type { AppThunk } from "../state/store";
 import * as selectors from "../state/selectors";
@@ -423,7 +422,7 @@ abstract class AstEdit extends Edit {
     super(from, to);
     this.parent = parent;
   }
-  abstract makeAstEdit(clonedAncestor: ClonedASTNode): void;
+  abstract makeAstEdit(clonedAncestor: ASTNode): void;
 }
 
 class InsertChildEdit extends AstEdit {
@@ -437,7 +436,7 @@ class InsertChildEdit extends AstEdit {
     this.fakeAstInsertion = new FakeAstInsertion(this.parent, field, pos);
   }
 
-  makeAstEdit(clonedAncestor: ClonedASTNode) {
+  makeAstEdit(clonedAncestor: ASTNode) {
     const clonedParent = findDescendantNode(clonedAncestor, this.parent.id);
     this.fakeAstInsertion.insertChild(clonedParent, this.text);
   }
@@ -467,7 +466,7 @@ class DeleteChildEdit extends AstEdit {
     return (this.prevId && newAST.getNodeById(this.prevId)) || "fallback";
   }
 
-  makeAstEdit(clonedAncestor: ClonedASTNode) {
+  makeAstEdit(clonedAncestor: ASTNode) {
     const clonedParent = findDescendantNode(clonedAncestor, this.parent.id);
     this.fakeAstReplacement.deleteChild(clonedParent);
   }
@@ -490,7 +489,7 @@ class ReplaceChildEdit extends AstEdit {
     this.fakeAstReplacement = new FakeAstReplacement(parent, node);
   }
 
-  makeAstEdit(clonedAncestor: ClonedASTNode) {
+  makeAstEdit(clonedAncestor: ASTNode) {
     const clonedParent = findDescendantNode(clonedAncestor, this.parent.id);
     this.fakeAstReplacement.replaceChild(clonedParent, this.text);
   }

--- a/packages/codemirror-blocks/src/toolkit/test-utils.tsx
+++ b/packages/codemirror-blocks/src/toolkit/test-utils.tsx
@@ -74,6 +74,9 @@ export function mountCMB(language: Language) {
         Object.assign(cmb, newAPI, {
           setBlockMode: (blockMode: boolean) =>
             act(() => newAPI.setBlockMode(blockMode)),
+          setValue: (value: string) => {
+            act(() => newAPI.setValue(value));
+          },
         });
       }}
       options={{ collapseAll: false, value: "", incrementalRendering: false }}


### PR DESCRIPTION
Make more properties of ASTNode readonly. This is for #412.

The main change here is that the `element` property is now a readonly getter which looks up the correct element in a mapping using the node's id. Now the only mutable properties left on ASTNode are the following: `id` `nid,` `level`, `ariaSetSize`, and `ariaPosInset`. Of these, `id` is the only one that is mutated outside of annotateNodes.