### PR TITLE
Focus the currently focused node when it mounts

### DIFF
--- a/packages/cmb-toolkit/src/simulate.ts
+++ b/packages/cmb-toolkit/src/simulate.ts
@@ -143,7 +143,7 @@ export function insertText(text: string) {
     // See https://github.com/testing-library/dom-testing-library/pull/235
     // for some discussion about this.
     fireEvent.input(activeEl, {
-      target: { innerHTML: text },
+      target: { innerHTML: activeEl.innerHTML + text },
     });
   }
 }
@@ -171,7 +171,7 @@ function makeKeyEvent<T extends Record<string, unknown>>(
 // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
 function getKeyCode(key: string): number {
   // The key code for an (uppercase) letter is that letter's ascii value.
-  if (key.match(/^[A-Z]$/)) {
+  if (key.match(/^[A-Za-z0-9]$/)) {
     return key.charCodeAt(0);
   }
   // The key code for a digit is that digit's ascii value.

--- a/packages/codemirror-blocks/spec/activation-test.ts
+++ b/packages/codemirror-blocks/spec/activation-test.ts
@@ -1,6 +1,5 @@
 import wescheme from "../src/languages/wescheme";
-import "codemirror/addon/search/searchcursor.js";
-
+import { screen } from "@testing-library/react";
 import {
   cmd_ctrl,
   teardown,
@@ -10,6 +9,7 @@ import {
   mountCMB,
   isNodeEditable,
   elementForNode,
+  keyPress,
 } from "../src/toolkit/test-utils";
 import { API } from "../src/CodeMirrorBlocks";
 import { ASTNode } from "../src/ast";
@@ -128,6 +128,27 @@ describe("when dealing with node activation,", () => {
     keyDown("Q", { altKey: true });
     expect(isNodeEditable(literal1)).toBe(false);
     expect(cmb.getValue()).toBe("11\n54");
+  });
+});
+
+describe("inserting a new node", () => {
+  let cmb: API;
+  beforeEach(() => {
+    cmb = mountCMB(wescheme).cmb;
+  });
+  it("should focus the node that was just inserted", () => {
+    cmb.focus();
+    // start inserting a new node
+    keyPress("a");
+    insertText("BrandNewLiteral");
+    // confirm the insertion by pressing Enter
+    keyDown("Enter");
+    // confirm that the new new was saved to the ast and focused
+    expect(cmb.getAst().toString()).toBe("aBrandNewLiteral");
+    expect(cmb.getValue()).toEqual("aBrandNewLiteral");
+    expect(document.activeElement!.id).toEqual(
+      screen.getByRole("treeitem", { name: /aBrandNewLiteral/ }).id
+    );
   });
 });
 

--- a/packages/codemirror-blocks/spec/activation-test.ts
+++ b/packages/codemirror-blocks/spec/activation-test.ts
@@ -172,6 +172,29 @@ describe("switching to block mode", () => {
   });
 });
 
+describe("deleting a top-level node", () => {
+  let cmb: API;
+  beforeEach(() => {
+    cmb = mountCMB(wescheme).cmb;
+  });
+  it("should focus on the previous node", () => {
+    cmb.setValue("firstLiteral\nsecondLiteral\nthirdLiteral");
+    mouseDown(screen.getByRole("treeitem", { name: /thirdLiteral/ }));
+    keyDown(" ");
+    keyDown("Delete");
+    expect(cmb.getValue()).toBe("firstLiteral\nsecondLiteral\n");
+    expect(
+      screen.getByRole("treeitem", { name: /secondLiteral/ })
+    ).toHaveFocus();
+    expect(cmb.getCursor()).toMatchInlineSnapshot(`
+      Object {
+        "ch": 0,
+        "line": 1,
+      }
+    `);
+  });
+});
+
 describe("cut/copy/paste", () => {
   let cmb!: API;
   let literal1!: ASTNode;

--- a/packages/codemirror-blocks/spec/activation-test.ts
+++ b/packages/codemirror-blocks/spec/activation-test.ts
@@ -10,6 +10,7 @@ import {
   isNodeEditable,
   elementForNode,
   keyPress,
+  click,
 } from "../src/toolkit/test-utils";
 import { API } from "../src/CodeMirrorBlocks";
 import { ASTNode } from "../src/ast";
@@ -146,9 +147,28 @@ describe("inserting a new node", () => {
     // confirm that the new new was saved to the ast and focused
     expect(cmb.getAst().toString()).toBe("aBrandNewLiteral");
     expect(cmb.getValue()).toEqual("aBrandNewLiteral");
-    expect(document.activeElement!.id).toEqual(
-      screen.getByRole("treeitem", { name: /aBrandNewLiteral/ }).id
-    );
+    expect(
+      screen.getByRole("treeitem", { name: /aBrandNewLiteral/ })
+    ).toHaveFocus();
+  });
+});
+
+describe("switching to block mode", () => {
+  let cmb: API;
+  beforeEach(() => {
+    cmb = mountCMB(wescheme).cmb;
+    cmb.setBlockMode(false);
+    cmb.setValue("foo bar");
+  });
+
+  it("should not change the focused element", () => {
+    const blockModeBtn = screen.getByRole("button", {
+      name: /Switch to blocks mode/,
+    });
+    blockModeBtn.focus();
+    expect(blockModeBtn).toHaveFocus();
+    click(blockModeBtn);
+    expect(blockModeBtn).toHaveFocus();
   });
 });
 

--- a/packages/codemirror-blocks/spec/activation-test.ts
+++ b/packages/codemirror-blocks/spec/activation-test.ts
@@ -172,12 +172,12 @@ describe("switching to block mode", () => {
   });
 });
 
-describe("deleting a top-level node", () => {
+describe("deleting a node", () => {
   let cmb: API;
   beforeEach(() => {
     cmb = mountCMB(wescheme).cmb;
   });
-  it("should focus on the previous node", () => {
+  it("should focus on the previous node when a top-level node is deleted", () => {
     cmb.setValue("firstLiteral\nsecondLiteral\nthirdLiteral");
     mouseDown(screen.getByRole("treeitem", { name: /thirdLiteral/ }));
     keyDown(" ");
@@ -192,6 +192,15 @@ describe("deleting a top-level node", () => {
         "line": 1,
       }
     `);
+  });
+
+  it("should focus on the previous child node when a child node is deleted", () => {
+    cmb.setValue("(someFunc firstArg secondArg)");
+    mouseDown(screen.getByRole("treeitem", { name: /secondArg/ }));
+    keyDown(" ");
+    keyDown("Delete");
+    expect(cmb.getValue()).toBe("(someFunc firstArg)");
+    expect(screen.getByRole("treeitem", { name: /firstArg/ })).toHaveFocus();
   });
 });
 

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -245,10 +245,15 @@ const Node = ({ expandable = true, ...props }: Props) => {
   const focusedNode = useSelector(selectors.getFocusedNode);
   useEffect(() => {
     if (
-      editor?.hasFocus() &&
-      nodeElementRef.current &&
-      focusedNode?.id === props.node.id
+      !editor?.hasFocus() &&
+      document.activeElement !== document.body &&
+      document.activeElement !== null
     ) {
+      // If the editor doesn't have focus, then we don't want to steal
+      // focus from something else.
+      return;
+    }
+    if (nodeElementRef.current && focusedNode?.id === props.node.id) {
       nodeElementRef.current?.focus();
     }
   }, [editor, focusedNode?.id, props.node.id]);

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -240,6 +240,15 @@ const Node = ({ expandable = true, ...props }: Props) => {
     }
   }, [props.node.id]);
 
+  // If this is the currently focused node, then focus the node element
+  // as soon as we finish rendering.
+  const focusedNode = useSelector(selectors.getFocusedNode);
+  useEffect(() => {
+    if (nodeElementRef.current && focusedNode?.id === props.node.id) {
+      nodeElementRef.current?.focus();
+    }
+  }, [focusedNode?.id, props.node.id]);
+
   if (editable) {
     if (!editor) {
       throw new Error("can't edit nodes before codemirror has mounted");

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -244,10 +244,14 @@ const Node = ({ expandable = true, ...props }: Props) => {
   // as soon as we finish rendering.
   const focusedNode = useSelector(selectors.getFocusedNode);
   useEffect(() => {
-    if (nodeElementRef.current && focusedNode?.id === props.node.id) {
+    if (
+      editor?.hasFocus() &&
+      nodeElementRef.current &&
+      focusedNode?.id === props.node.id
+    ) {
       nodeElementRef.current?.focus();
     }
-  }, [focusedNode?.id, props.node.id]);
+  }, [editor, focusedNode?.id, props.node.id]);
 
   if (editable) {
     if (!editor) {

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -247,7 +247,8 @@ const Node = ({ expandable = true, ...props }: Props) => {
     if (
       !editor?.hasFocus() &&
       document.activeElement !== document.body &&
-      document.activeElement !== null
+      document.activeElement !== null &&
+      document.activeElement.id !== "SR_fix_for_slow_dom"
     ) {
       // If the editor doesn't have focus, then we don't want to steal
       // focus from something else.

--- a/packages/codemirror-blocks/src/components/NodeEditable.tsx
+++ b/packages/codemirror-blocks/src/components/NodeEditable.tsx
@@ -52,127 +52,151 @@ type Props = Omit<ContentEditableProps, "value"> & {
   editor: CMBEditor;
 };
 
-const NodeEditable = (props: Props) => {
-  const element = useRef<HTMLElement>(null);
-  const dispatch: AppDispatch = useDispatch();
+export type NodeEditableHandle = {
+  /**
+   * Selects and focuses the text in the node editable component
+   */
+  select: () => void;
+};
 
-  const ast = useSelector(selectors.getAST);
+const NodeEditable = React.forwardRef<NodeEditableHandle, Props>(
+  (props, ref) => {
+    const element = useRef<HTMLElement>(null);
+    const dispatch: AppDispatch = useDispatch();
 
-  const { initialValue, isErrored } = useSelector((state: RootState) => {
-    const nodeId = props.target.node ? props.target.node.id : "editing";
-    const isErrored = selectors.getErrorId(state) == nodeId;
+    const ast = useSelector(selectors.getAST);
 
-    const initialValue =
-      props.value === null ? props.target.getText(ast, props.editor) : "";
+    const { initialValue, isErrored } = useSelector((state: RootState) => {
+      const nodeId = props.target.node ? props.target.node.id : "editing";
+      const isErrored = selectors.getErrorId(state) == nodeId;
 
-    return { isErrored, initialValue };
-  });
+      const initialValue =
+        props.value === null ? props.target.getText(ast, props.editor) : "";
 
-  // select and focus the element on mount
-  useEffect(() => {
-    const currentEl = element.current;
-    if (!currentEl) {
-      // element has been unmounted already, nothing to do.
-      return;
-    }
-    selectElement(currentEl, props.isInsertion);
-  }, [props.isInsertion]);
+      return { isErrored, initialValue };
+    });
 
-  useEffect(() => {
-    const text = props.value || initialValue || "";
-    const annt = (props.isInsertion ? "inserting" : "editing") + ` ${text}`;
-    say(annt + `.  Use Enter to save, and Alt-Q to cancel`);
-    dispatch(actions.setSelectedNodeIds([]));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const onBlur = (e: React.SyntheticEvent) => {
-    e.stopPropagation();
-    const { target } = props;
-    dispatch((dispatch: AppDispatch, getState: () => RootState) => {
-      // we grab the value directly from the content editable element
-      // to deal with this issue:
-      // https://github.com/lovasoa/react-contenteditable/issues/161
-      const value = element.current?.textContent;
-      const focusedNode = selectors.getFocusedNode(getState());
-      // if there's no insertion value, or the new value is the same as the
-      // old one, preserve focus on original node and return silently
-      if (value === initialValue || !value) {
-        props.onDisableEditable();
-        const nid = focusedNode && focusedNode.nid;
-        dispatch(activateByNid(props.editor, nid));
+    // select and focus the element on mount
+    useEffect(() => {
+      const currentEl = element.current;
+      if (!currentEl) {
+        // element has been unmounted already, nothing to do.
         return;
       }
+      selectElement(currentEl, props.isInsertion);
+    }, [props.isInsertion]);
 
-      const annt = `${props.isInsertion ? "inserted" : "changed"} ${value}`;
-      const result = dispatch(insert(value, target, props.editor, annt));
-      if (result.successful) {
-        dispatch(activateByNid(props.editor, null, { allowMove: false }));
-        props.onChange(null);
-        props.onDisableEditable();
-        dispatch(actions.clearError());
-        say(annt);
-      } else {
-        console.error(result.exception);
-        dispatch(actions.setErrorId(target.node ? target.node.id : "editing"));
+    // expose an imperative handle for selecting the contents
+    // of the rendered element in case it needs to be done after
+    // later. This is only necessary in cases where the component
+    // is rendered to a container that won't be in the document
+    // until later, as is the case with TopLevelNodeEditable
+    React.useImperativeHandle(ref, () => ({
+      select: () => {
         if (element.current) {
-          selectElement(element.current, false);
+          selectElement(element.current, props.isInsertion);
+        }
+      },
+    }));
+
+    useEffect(() => {
+      const text = props.value || initialValue || "";
+      const annt = (props.isInsertion ? "inserting" : "editing") + ` ${text}`;
+      say(annt + `.  Use Enter to save, and Alt-Q to cancel`);
+      dispatch(actions.setSelectedNodeIds([]));
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const onBlur = (e: React.SyntheticEvent) => {
+      e.stopPropagation();
+      const { target } = props;
+      dispatch((dispatch: AppDispatch, getState: () => RootState) => {
+        // we grab the value directly from the content editable element
+        // to deal with this issue:
+        // https://github.com/lovasoa/react-contenteditable/issues/161
+        const value = element.current?.textContent;
+        const focusedNode = selectors.getFocusedNode(getState());
+        // if there's no insertion value, or the new value is the same as the
+        // old one, preserve focus on original node and return silently
+        if (value === initialValue || !value) {
+          props.onDisableEditable();
+          const nid = focusedNode && focusedNode.nid;
+          dispatch(activateByNid(props.editor, nid));
+          return;
+        }
+
+        const annt = `${props.isInsertion ? "inserted" : "changed"} ${value}`;
+        const result = dispatch(insert(value, target, props.editor, annt));
+        if (result.successful) {
+          dispatch(activateByNid(props.editor, null, { allowMove: false }));
+          props.onChange(null);
+          props.onDisableEditable();
+          dispatch(actions.clearError());
+          say(annt);
+        } else {
+          console.error(result.exception);
+          dispatch(
+            actions.setErrorId(target.node ? target.node.id : "editing")
+          );
+          if (element.current) {
+            selectElement(element.current, false);
+          }
+        }
+      });
+    };
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const el = e.target as HTMLDivElement;
+      switch (CodeMirror.keyName(e)) {
+        case "Enter": {
+          // blur the element to trigger handleBlur
+          // which will save the edit
+          element.current?.blur();
+          return;
+        }
+        case "Alt-Q":
+        case "Esc": {
+          el.innerHTML = initialValue;
+          e.stopPropagation();
+          props.onChange(null);
+          props.onDisableEditable();
+          dispatch(actions.clearError());
+          dispatch(activateByNid(props.editor, null, { allowMove: false }));
+          return;
         }
       }
-    });
-  };
+    };
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    const el = e.target as HTMLDivElement;
-    switch (CodeMirror.keyName(e)) {
-      case "Enter": {
-        // blur the element to trigger handleBlur
-        // which will save the edit
-        element.current?.blur();
-        return;
-      }
-      case "Alt-Q":
-      case "Esc": {
-        el.innerHTML = initialValue;
-        e.stopPropagation();
-        props.onChange(null);
-        props.onDisableEditable();
-        dispatch(actions.clearError());
-        dispatch(activateByNid(props.editor, null, { allowMove: false }));
-        return;
-      }
-    }
-  };
+    const { contentEditableProps, extraClasses, value } = props;
 
-  const { contentEditableProps, extraClasses, value } = props;
-
-  const classes = (
-    [
-      "blocks-literal",
-      "quarantine",
-      "blocks-editing",
-      "blocks-node",
-      { "blocks-error": isErrored },
-    ] as ClassNamesArgument[]
-  ).concat(extraClasses);
-  const text = value ?? initialValue;
-  return (
-    <ContentEditable
-      {...contentEditableProps}
-      className={classNames(classes)}
-      role="textbox"
-      ref={element}
-      onChange={props.onChange}
-      onBlur={onBlur}
-      onKeyDown={onKeyDown}
-      // trap mousedown, clicks and doubleclicks, to prevent focus change, or
-      // parent nodes from toggling collapsed state
-      onMouseDown={suppressEvent}
-      onClick={suppressEvent}
-      onDoubleClick={suppressEvent}
-      aria-label={text}
-      value={text}
-    />
-  );
-};
+    const classes = (
+      [
+        "blocks-literal",
+        "quarantine",
+        "blocks-editing",
+        "blocks-node",
+        { "blocks-error": isErrored },
+      ] as ClassNamesArgument[]
+    ).concat(extraClasses);
+    const text = value ?? initialValue;
+    return (
+      <ContentEditable
+        {...contentEditableProps}
+        className={classNames(classes)}
+        role="textbox"
+        ref={element}
+        onChange={props.onChange}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+        // trap mousedown, clicks and doubleclicks, to prevent focus change, or
+        // parent nodes from toggling collapsed state
+        onMouseDown={suppressEvent}
+        onClick={suppressEvent}
+        onDoubleClick={suppressEvent}
+        aria-label={text}
+        value={text}
+      />
+    );
+  }
+);
 export default NodeEditable;

--- a/packages/codemirror-blocks/src/editor.ts
+++ b/packages/codemirror-blocks/src/editor.ts
@@ -134,6 +134,11 @@ export interface ReadonlyCMBEditor extends ReadonlyRangedText {
     start: Pos,
     options: { caseFold: boolean }
   ): CodeMirror.SearchCursor;
+
+  /**
+   * Whether or not the editor currently has focus
+   */
+  hasFocus(): boolean;
 }
 
 export interface RangedText extends ReadonlyRangedText {
@@ -230,6 +235,9 @@ export class CodeMirrorFacade implements CMBEditor {
     origin: string | undefined
   ): void {
     this.codemirror.replaceRange(replacement, from, to, origin);
+  }
+  hasFocus(): boolean {
+    return this.codemirror.hasFocus();
   }
   focus(): void {
     this.codemirror.focus();

--- a/packages/codemirror-blocks/src/state/actions.ts
+++ b/packages/codemirror-blocks/src/state/actions.ts
@@ -330,7 +330,7 @@ export function activateByNid(
     // which confuses the screenreader. In these situations, we focus on
     // a dummy element that just says "stand by" (see ToggleEditor.js).
     // When the new node is available, focus will shift automatically.
-    if (!document.contains(newNode.element)) {
+    if (newNode.element && !document.contains(newNode.element)) {
       const sr = document.getElementById("SR_fix_for_slow_dom");
       // In the event that everything has been unmounted,
       // for example in a unit test, then neither newNode.element nor


### PR DESCRIPTION
Fixes #591

This ended up being surprisingly complicated. The solution to the actual problem was simple: add a useEffect() that focuses the currently focused node when it mounts. Doing this worked fine and all the tests passed, except there was a cryptic react warning message that showed up when the tests ran. The warning only showed up in tests and not when doing exactly the same thing in the browser.

The issue has to do with the timing of calls to `focus(),` though not the call to `focus()` that I added, but rather one that's been in there already for a while, and which is deeply buried in codemirror in the call to `setBookmark()`. I don't know why the warnings didn't show up until I made this change. In any case, you are theoretically not supposed to monkey with the dom (e.g. by calling `focus()`) while react is rendering, and instead use `useEffect()` to wait until rendering is finished, but we were calling `setBookmark()` while rendering `ToplevelBlockEditable`.

Anyway, to fix the issue, I moved the call to `setBookmark()` to happen inside a `useEffect()`, which resulted in a different problem. The order in which `useEffect()` callbacks are called is depth first. So the `useEffect()` inside `NodeEditable` which selects the text as soon as the NodeEditable component mounts was being called _before_ it's parent component's `useEffect()` had called `setBookmark()`, so text could node be selected because it wasn't in the document yet.

To avoid the troubles with using `setAfterDOMUpdate` or similar to "wait until react is done", I had to move responsibility for calling selectElement() up the component hierarchy to `ToplevelBlockEditable`. So now we only select the element text _after_ it's container element has been inserted into the document via `setBookmark()`. It's the first time I've had the chance to use [`useImperativeHandle()`](https://reactjs.org/docs/hooks-reference.html#useimperativehandle).

codemirror really makes things 10x more complicated than they would otherwise be, but I hope the comments I've left behind are explanatory enough.