### PR TITLE
Stop rendering nodes that haven't changed after an edit

### DIFF
--- a/packages/codemirror-blocks/spec/ui/Node-test.tsx
+++ b/packages/codemirror-blocks/spec/ui/Node-test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import React from "react";
 import { AST } from "../../src/ast";
-import Context, { LanguageContext } from "../../src/components/Context";
+import Context from "../../src/components/Context";
 import Node from "../../src/components/Node";
 import { addLanguage } from "../../src/languages";
 import { Comment, Literal } from "../../src/nodes";
@@ -19,11 +19,7 @@ const testLang = addLanguage({
 });
 
 const renderWithContext = (el: React.ReactElement) =>
-  render(
-    <Context store={store}>
-      <LanguageContext.Provider value={testLang}>{el}</LanguageContext.Provider>
-    </Context>
-  );
+  render(<Context store={store}>{el}</Context>);
 
 it("renders a draggable span with various aria properties", () => {
   const ast = AST.from(testLang.id, [

--- a/packages/codemirror-blocks/spec/ui/NodeEditable-test.tsx
+++ b/packages/codemirror-blocks/spec/ui/NodeEditable-test.tsx
@@ -6,20 +6,9 @@ import NodeEditable from "../../src/components/NodeEditable";
 import { AppStore, createAppStore } from "../../src/state/store";
 import { say } from "../../src/announcer";
 import { CodeMirrorFacade } from "../../src/editor";
-import Context, { LanguageContext } from "../../src/components/Context";
-import { Language } from "../../src/CodeMirrorBlocks";
-import { addLanguage } from "../../src/languages";
+import Context from "../../src/components/Context";
 
 jest.mock("../../src/announcer");
-
-let testLang!: Language;
-beforeAll(() => {
-  testLang = addLanguage({
-    id: "some-lang-id",
-    name: "some lang",
-    parse: jest.fn(),
-  });
-});
 
 afterEach(cleanup);
 
@@ -43,13 +32,7 @@ describe("NodeEditable", () => {
     editor.codemirror.getWrapperElement().remove();
   });
   const renderWithContext = (el: React.ReactElement) =>
-    render(
-      <Context store={store}>
-        <LanguageContext.Provider value={testLang}>
-          {el}
-        </LanguageContext.Provider>
-      </Context>
-    );
+    render(<Context store={store}>{el}</Context>);
 
   describe("when editing text (isInsertion=false)", () => {
     describe("after first mount", () => {

--- a/packages/codemirror-blocks/src/components/Context.tsx
+++ b/packages/codemirror-blocks/src/components/Context.tsx
@@ -2,12 +2,10 @@ import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { Provider } from "react-redux";
-import type { Language } from "../CodeMirrorBlocks";
 import { CMBEditor } from "../editor";
 import type { AppStore } from "../state/store";
 
 export const EditorContext = React.createContext<CMBEditor | null>(null);
-export const LanguageContext = React.createContext<Language | null>(null);
 
 export type AppHelpers = {
   /**

--- a/packages/codemirror-blocks/src/components/DropTarget.tsx
+++ b/packages/codemirror-blocks/src/components/DropTarget.tsx
@@ -5,7 +5,7 @@ import { useDrop } from "react-dnd";
 import classNames from "classnames";
 import { AppDispatch } from "../state/store";
 import { genUniqueId } from "../utils";
-import { useDropAction, InsertTarget } from "../state/actions";
+import * as actions from "../state/actions";
 import * as selectors from "../state/selectors";
 import type { ASTNode, AST, Pos } from "../ast";
 import { ItemTypes } from "../dnd";
@@ -166,10 +166,9 @@ field declared. The node was:`,
     if (!pos) {
       throw new Error(`Can't determine location for InsertTarget`);
     }
-    return new InsertTarget(node, props.field, pos);
+    return new actions.InsertTarget(node, props.field, pos);
   };
 
-  const drop = useDropAction();
   const [{ isOver }, connectDropTarget] = useDrop({
     accept: ItemTypes.NODE,
     drop: (item: { id: string; content: string }, monitor) => {
@@ -180,7 +179,7 @@ field declared. The node was:`,
       if (monitor.didDrop()) {
         return;
       }
-      return drop(editor, item, createTarget());
+      return dispatch(actions.drop(editor, item, createTarget()));
     },
     collect: (monitor) => {
       return { isOver: monitor.isOver({ shallow: true }) };

--- a/packages/codemirror-blocks/src/components/DropTarget.tsx
+++ b/packages/codemirror-blocks/src/components/DropTarget.tsx
@@ -8,7 +8,6 @@ import { genUniqueId } from "../utils";
 import { useDropAction, InsertTarget } from "../state/actions";
 import * as selectors from "../state/selectors";
 import type { ASTNode, AST, Pos } from "../ast";
-import { RootState } from "../state/reducers";
 import { ItemTypes } from "../dnd";
 import { EditorContext } from "./Context";
 
@@ -147,9 +146,7 @@ field declared. The node was:`,
 
   const dispatch: AppDispatch = useDispatch();
   const ast = useSelector(selectors.getAST);
-  const { isEditable } = useSelector((state: RootState) => {
-    return { isEditable: state.editable[id] ?? false };
-  });
+  const isEditable = useSelector(selectors.getEditable)[id] ?? false;
   // These `isEditable` and `setEditable` methods allow DropTargetSiblings to
   // check to see whether an adjacent DropTarget is being edited, or, for when the
   // insert-left or insert-right shortcut is pressed, _set_ an adjacent DropTarget

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -1,11 +1,7 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AST, ASTNode, nodeElementMap } from "../ast";
-import {
-  useDropAction,
-  ReplaceNodeTarget,
-  collapseNode,
-} from "../state/actions";
+import { ReplaceNodeTarget, collapseNode } from "../state/actions";
 import * as actions from "../state/actions";
 import NodeEditable from "./NodeEditable";
 import { NodeContext, findAdjacentDropTargetId } from "./DropTarget";
@@ -183,7 +179,6 @@ const Node = ({ expandable = true, ...props }: Props) => {
     { "blocks-locked": locked },
     `blocks-${props.node.type}`,
   ];
-  const drop = useDropAction();
   const ast = useSelector(selectors.getAST);
   const [{ isOver }, connectDropTarget] = useDrop({
     accept: ItemTypes.NODE,
@@ -196,7 +191,9 @@ const Node = ({ expandable = true, ...props }: Props) => {
         return;
       }
       const node = ast.getNodeByIdOrThrow(props.node.id);
-      return drop(editor, monitor.getItem(), new ReplaceNodeTarget(node));
+      return dispatch(
+        actions.drop(editor, monitor.getItem(), new ReplaceNodeTarget(node))
+      );
     },
     collect: (monitor) => {
       return {

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -179,7 +179,6 @@ const Node = ({ expandable = true, ...props }: Props) => {
     { "blocks-locked": locked },
     `blocks-${props.node.type}`,
   ];
-  const ast = useSelector(selectors.getAST);
   const [{ isOver }, connectDropTarget] = useDrop({
     accept: ItemTypes.NODE,
     drop: (_item, monitor) => {
@@ -190,10 +189,13 @@ const Node = ({ expandable = true, ...props }: Props) => {
       if (monitor.didDrop()) {
         return;
       }
-      const node = ast.getNodeByIdOrThrow(props.node.id);
-      return dispatch(
-        actions.drop(editor, monitor.getItem(), new ReplaceNodeTarget(node))
-      );
+      return dispatch((dispatch, getState) => {
+        const ast = selectors.getAST(getState());
+        const node = ast.getNodeByIdOrThrow(props.node.id);
+        return dispatch(
+          actions.drop(editor, monitor.getItem(), new ReplaceNodeTarget(node))
+        );
+      });
     },
     collect: (monitor) => {
       return {

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -16,7 +16,7 @@ import { useDrag, useDrop } from "react-dnd";
 import { RootState } from "../state/reducers";
 import { isDummyPos } from "../utils";
 import { keyDown } from "../keymap";
-import { AppContext, EditorContext, LanguageContext } from "./Context";
+import { AppContext, EditorContext } from "./Context";
 import { RootNodeContext } from "../ui/ToplevelBlock";
 import * as selectors from "../state/selectors";
 
@@ -70,7 +70,6 @@ const Node = ({ expandable = true, ...props }: Props) => {
   const editor = useContext(EditorContext);
 
   const dispatch: AppDispatch = useDispatch();
-  const language = useContext(LanguageContext);
   const appHelpers = useContext(AppContext);
   const isErrorFree = useSelector(selectors.isErrorFree);
 
@@ -86,17 +85,11 @@ const Node = ({ expandable = true, ...props }: Props) => {
       // codemirror hasn't mounted yet, do nothing.
       return;
     }
-    if (!language) {
-      throw new Error(
-        `Can't handle keyDown events outside of a language context`
-      );
-    }
     dispatch(
       keyDown(e, {
         isNodeEnv: true,
         node: props.node,
         editor: editor,
-        language: language,
         appHelpers: appHelpers,
         handleMakeEditable,
         setLeft: (ast: AST) => {

--- a/packages/codemirror-blocks/src/components/Node.tsx
+++ b/packages/codemirror-blocks/src/components/Node.tsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { AST, ASTNode, nodeElementMap } from "../ast";
 import {
   useDropAction,
-  activateByNid,
   ReplaceNodeTarget,
   collapseNode,
 } from "../state/actions";
@@ -55,8 +54,6 @@ const Node = ({ expandable = true, ...props }: Props) => {
   const textMarker = useSelector((state: RootState) =>
     selectors.getTextMarker(state, props.node)
   );
-  const ast = useSelector(selectors.getAST);
-
   const rootNode = useContext(RootNodeContext);
   useEffect(() => {
     // Whenever a node gets rerendered because it's collapsed state has changed,
@@ -132,8 +129,6 @@ const Node = ({ expandable = true, ...props }: Props) => {
     }
   };
 
-  // nid can be stale!! Always obtain a fresh copy of the node
-  // from getState() before calling activateByNid
   const handleMouseDown = (e: React.MouseEvent) => {
     if (!editor) {
       // codemirror hasn't mounted yet, do nothing
@@ -150,8 +145,7 @@ const Node = ({ expandable = true, ...props }: Props) => {
       // TODO(Oak): is this the best way?
       return;
     }
-    const currentNode = ast.getNodeByIdOrThrow(props.node.id);
-    dispatch(activateByNid(editor, currentNode.nid, { allowMove: false }));
+    dispatch(actions.activateNode(editor, props.node, { allowMove: false }));
   };
 
   const handleDoubleClick = (e: React.MouseEvent) => {
@@ -197,6 +191,7 @@ const Node = ({ expandable = true, ...props }: Props) => {
     `blocks-${props.node.type}`,
   ];
   const drop = useDropAction();
+  const ast = useSelector(selectors.getAST);
   const [{ isOver }, connectDropTarget] = useDrop({
     accept: ItemTypes.NODE,
     drop: (_item, monitor) => {

--- a/packages/codemirror-blocks/src/keymap.tsx
+++ b/packages/codemirror-blocks/src/keymap.tsx
@@ -24,7 +24,6 @@ import { findAdjacentDropTargetId as getDTid } from "./components/DropTarget";
 import type { AppThunk } from "./state/store";
 import type { AST, ASTNode } from "./ast";
 import { CMBEditor } from "./editor";
-import { Language } from "./CodeMirrorBlocks";
 import type { AppHelpers } from "./components/Context";
 import * as selectors from "./state/selectors";
 import { copy } from "./copypaste";
@@ -33,7 +32,6 @@ type BlockEditorEnv = {
   isNodeEnv: false;
   appHelpers: AppHelpers;
   editor: CMBEditor;
-  language: Language;
 };
 
 type NodeEnv = {
@@ -42,7 +40,6 @@ type NodeEnv = {
   appHelpers: AppHelpers;
 
   editor: CMBEditor;
-  language: Language;
   handleMakeEditable: (e?: React.KeyboardEvent) => void;
   setRight: (ast: AST) => boolean;
   setLeft: (ast: AST) => boolean;

--- a/packages/codemirror-blocks/src/state/actions.ts
+++ b/packages/codemirror-blocks/src/state/actions.ts
@@ -296,11 +296,29 @@ export function useDropAction() {
   };
 }
 
+type ActivateOptions = { allowMove?: boolean; record?: boolean };
+
+export function activateNode(
+  editor: ReadonlyCMBEditor,
+  node: ASTNode,
+  options: ActivateOptions
+): AppThunk {
+  return (dispatch, getState) => {
+    const ast = selectors.getAST(getState());
+    // nid can be stale!! Always obtain a fresh copy of the node
+    // from getState() before calling activateByNid
+    // TODO(pcardune): figure out why this is the case and make it
+    // not the case.
+    const currentNode = ast.getNodeByIdOrThrow(node.id);
+    dispatch(activateByNid(editor, currentNode.nid, options));
+  };
+}
+
 // Activate the node with the given `nid`.
 export function activateByNid(
   editor: ReadonlyCMBEditor,
   nid: number | null,
-  options: { allowMove?: boolean; record?: boolean } = {}
+  options: ActivateOptions = {}
 ): AppThunk {
   return (dispatch, getState) => {
     options = { ...options, allowMove: true, record: true };

--- a/packages/codemirror-blocks/src/state/actions.ts
+++ b/packages/codemirror-blocks/src/state/actions.ts
@@ -20,8 +20,6 @@ import { CMBEditor, ReadonlyCMBEditor, ReadonlyRangedText } from "../editor";
 import { useDispatch } from "react-redux";
 import type { Language } from "../CodeMirrorBlocks";
 import { err, ok, Result } from "../edits/result";
-import { useContext } from "react";
-import { LanguageContext } from "../components/Context";
 import * as selectors from "./selectors";
 import { pasteFromClipboard } from "../copypaste";
 
@@ -242,15 +240,11 @@ export function useDropAction() {
   // Drag from `src` (which should be a d&d monitor thing) to `target`.
   // See the comment at the top of the file for what kinds of `target` there are.
   const dispatch: AppDispatch = useDispatch();
-  const language = useContext(LanguageContext);
   return function drop(
     editor: CMBEditor,
     src: { id: string; content: string },
     target: Target
   ) {
-    if (!language) {
-      throw new Error(`Can't use dropAction outside of a language context`);
-    }
     checkTarget(target);
     const { id: srcId, content: srcContent } = src;
     dispatch((dispatch, getState) => {

--- a/packages/codemirror-blocks/src/state/selectors.ts
+++ b/packages/codemirror-blocks/src/state/selectors.ts
@@ -8,7 +8,10 @@ const getNode = (state: RootState, node: ASTNode) => node;
 /**
  * Get an AST object using data from the store
  */
-export const getAST = (state: RootState) => new AST(state.astData);
+export const getAST: (state: RootState) => AST = createSelector(
+  [(state: RootState) => state.astData],
+  (astData) => new AST(astData)
+);
 
 /**
  * Get the entire list of collapsed nodes.

--- a/packages/codemirror-blocks/src/state/selectors.ts
+++ b/packages/codemirror-blocks/src/state/selectors.ts
@@ -116,3 +116,5 @@ export const isBlockModeEnabled = (state: RootState) => state.blockMode;
  * @returns a string representation of the code.
  */
 export const getCode = (state: RootState) => state.code;
+
+export const getEditable = (state: RootState) => state.editable;

--- a/packages/codemirror-blocks/src/ui/BlockEditor.tsx
+++ b/packages/codemirror-blocks/src/ui/BlockEditor.tsx
@@ -15,7 +15,7 @@ import type { AppDispatch } from "../state/store";
 import * as selectors from "../state/selectors";
 import * as actions from "../state/actions";
 import type { IUnControlledCodeMirror } from "react-codemirror2";
-import { EditorContext, LanguageContext } from "../components/Context";
+import { EditorContext } from "../components/Context";
 import { CodeMirrorFacade, Pos, ReadonlyCMBEditor } from "../editor";
 import ToplevelBlockEditable from "./ToplevelBlockEditable";
 import { isChangeObject, makeChangeObject } from "../edits/performEdits";
@@ -261,7 +261,7 @@ const BlockEditor = ({ options = {}, ...props }: BlockEditorProps) => {
   };
 
   return (
-    <LanguageContext.Provider value={language}>
+    <>
       <DragAndDropEditor
         options={props.codemirrorOptions}
         className={`blocks-language-${language.id}`}
@@ -272,7 +272,6 @@ const BlockEditor = ({ options = {}, ...props }: BlockEditorProps) => {
         onKeyDown={(editor, e) => {
           dispatch(
             keyDown(e, {
-              language: language,
               editor,
               isNodeEnv: false,
               appHelpers: props.keyDownHelpers,
@@ -283,7 +282,7 @@ const BlockEditor = ({ options = {}, ...props }: BlockEditorProps) => {
         editorDidMount={handleEditorDidMount}
       />
       {renderPortals()}
-    </LanguageContext.Provider>
+    </>
   );
 };
 export default BlockEditor;

--- a/packages/codemirror-blocks/src/ui/DragAndDropEditor.tsx
+++ b/packages/codemirror-blocks/src/ui/DragAndDropEditor.tsx
@@ -5,10 +5,11 @@ import {
 } from "react-codemirror2";
 import React, { useRef } from "react";
 import { ItemTypes } from "../dnd";
-import { OverwriteTarget, useDropAction } from "../state/actions";
+import * as actions from "../state/actions";
 import { playSound, BEEP } from "../utils";
 import { useDrop } from "react-dnd";
 import { CodeMirrorFacade } from "../editor";
+import { useDispatch } from "react-redux";
 
 type OurProps = {
   editorDidMount?: (ed: CodeMirror.Editor) => void;
@@ -21,8 +22,7 @@ type Props = Omit<IUnControlledCodeMirror, keyof OurProps> & OurProps;
 
 const DragAndDropEditor = (props: Props) => {
   const editorRef = useRef<CodeMirrorFacade>();
-  const drop = useDropAction();
-
+  const dispatch = useDispatch();
   const [_, connectDropTarget] = useDrop({
     accept: ItemTypes.NODE,
     drop: (_, monitor) => {
@@ -50,10 +50,12 @@ const DragAndDropEditor = (props: Props) => {
         // If it's in a valid part of CM whitespace, translate to "insert at loc" edit
         if (isDroppedOnWhitespace) {
           const loc = editorRef.current.codemirror.coordsChar({ left, top });
-          drop(
-            editorRef.current,
-            monitor.getItem(),
-            new OverwriteTarget(loc, loc)
+          dispatch(
+            actions.drop(
+              editorRef.current,
+              monitor.getItem(),
+              new actions.OverwriteTarget(loc, loc)
+            )
           );
           // Or else beep and make it a no-op
         } else {


### PR DESCRIPTION
While trying to understand all the different focusing stuff, I noticed that some elements were being re-rendered even though nothing that they were rendering had changed. For example, editing one node in the ast would cause all other nodes to rerender upon saving the edit.

There were two main culprits:
1. using `useSelector` to get things from the redux store which were only used in event handlers (i.e. not for rendering).
2. selectors that were not memoized, returning a new value every time they were used even though the state used to construct that value hadn't changed.

In making the necessary changes to address these issues, I also did a bit of refactoring in a few places:
- Removing the LanguageContext which was no longer being used after #588 
- Removing `useDropAction`, which was a poor decision on my part to have in the first place instead of just sticking with plain calls to dispatch()