### PR TITLE
make codemirror-pane dimensions more robust (see #585)

### DIFF
--- a/packages/codemirror-blocks/src/ui/Editor.less
+++ b/packages/codemirror-blocks/src/ui/Editor.less
@@ -4,7 +4,6 @@
   position: absolute;
   width: 100%;
   display: flex;
-  flex-wrap: wrap;
   user-select: none;
   -webkit-user-select: none;
   .glyphicon {

--- a/packages/codemirror-blocks/src/ui/Editor.less
+++ b/packages/codemirror-blocks/src/ui/Editor.less
@@ -22,6 +22,7 @@
   }
   .react-codemirror2 {
     width: 100%;
+    height: 100%;
   }
 
   > .toolbar-pane {
@@ -37,6 +38,10 @@
   > .codemirror-pane {
     padding: 0px 0px;
     flex-grow: 1;
+    > div {
+      width: 100%;
+      height: 100%;
+    }
   }
 
   > .Toolbar {

--- a/packages/codemirror-blocks/src/ui/PrimitiveList.less
+++ b/packages/codemirror-blocks/src/ui/PrimitiveList.less
@@ -1,6 +1,8 @@
 .PrimitiveList {
   padding-left: 0px;
-  li { list-style-type: none; }
+  li {
+    list-style-type: none;
+  }
   .Primitive {
     padding: 5px;
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;

--- a/packages/codemirror-blocks/src/ui/PrimitiveList.less
+++ b/packages/codemirror-blocks/src/ui/PrimitiveList.less
@@ -1,11 +1,12 @@
 .PrimitiveList {
   padding-left: 0px;
+  li { list-style-type: none; }
   .Primitive {
     padding: 5px;
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
     color: steelblue;
     border: 0px;
-    list-style-type: none;
+    border-radius: 0px;
 
     &.selected {
       background: #ffb;


### PR DESCRIPTION
This doesn't appear to change anything in our example, but should improve behavior on WeScheme (and other editors).