### PR TITLE
Fix drag/drop focusing for nodes with children

### DIFF
--- a/packages/codemirror-blocks/spec/drag-test.ts
+++ b/packages/codemirror-blocks/spec/drag-test.ts
@@ -1,6 +1,4 @@
 import wescheme from "../src/languages/wescheme";
-import "codemirror/addon/search/searchcursor.js";
-
 import {
   teardown,
   mouseDown,
@@ -17,101 +15,93 @@ import { ASTNode } from "../src/ast";
 import { FunctionAppNode } from "../src/nodes";
 import { fireEvent } from "@testing-library/react";
 
-describe("Drag and drop", () => {
-  let cmb!: API;
+let cmb!: API;
+beforeEach(() => {
+  cmb = mountCMB(wescheme).cmb;
+});
+
+afterEach(teardown);
+
+describe("when drag existing node and drop on existing node,", () => {
+  let firstArg: ASTNode;
+  let secondArg: ASTNode;
+  let dropTargetEls: NodeListOf<Element>;
+
+  const retrieve = () => {
+    const funcApp = cmb.getAst().rootNodes[0] as FunctionAppNode;
+    firstArg = funcApp.fields.args[0];
+    secondArg = funcApp.fields.args[1];
+    dropTargetEls = cmb
+      .getAst()
+      .rootNodes[0].element!.querySelectorAll(".blocks-drop-target");
+  };
+
   beforeEach(() => {
-    cmb = mountCMB(wescheme).cmb;
+    cmb.setValue("(+ 1 2 3)");
+    retrieve();
   });
 
-  afterEach(teardown);
+  it("should override nodes 1", () => {
+    expect(secondArg.element!.textContent).toBe("2");
+    const dragEvent = dragstart();
+    fireEvent(firstArg.element!, dragEvent);
+    fireEvent(secondArg.element!, drop());
+    retrieve();
+    expect(secondArg.element!.textContent).toBe("3");
+  });
 
-  describe("when drag existing node and drop on existing node,", () => {
-    let firstArg: ASTNode;
-    let secondArg: ASTNode;
-    let dropTargetEls: NodeListOf<Element>;
+  it("should set the right css class on dragenter 2", () => {
+    const dragEvent = dragstart();
+    fireEvent(firstArg.element!, dragEvent);
+    const elt = dropTargetEls[3];
+    expect(elt.classList).toContain("blocks-drop-target");
+    dragenterSeq(elt);
+    expect(elt.classList).toContain("blocks-over-target");
+  });
 
-    const retrieve = () => {
-      const funcApp = cmb.getAst().rootNodes[0] as FunctionAppNode;
-      firstArg = funcApp.fields.args[0];
-      secondArg = funcApp.fields.args[1];
-      dropTargetEls = cmb
-        .getAst()
-        .rootNodes[0].element!.querySelectorAll(".blocks-drop-target");
-    };
+  it("should set the right css class on dragleave 3", () => {
+    const dragEvent = dragstart();
+    fireEvent(firstArg.element!, dragEvent);
+    const elt = dropTargetEls[3];
+    dragenter();
+    dragleave();
+    expect(elt.classList).not.toContain("blocks-over-target");
+  });
 
-    beforeEach(async () => {
-      cmb.setValue("(+ 1 2 3)");
-      retrieve();
-    });
+  it("should do nothing when dragging over a non-drop target 4", () => {
+    const dragEvent = dragstart();
+    fireEvent(firstArg.element!, dragEvent);
+    const nonDT = cmb.getAst().rootNodes[0].element!;
+    dragenterSeq(nonDT);
+    expect(secondArg.element!.classList).not.toContain("blocks-over-target");
+  });
 
-    it("should override nodes 1", () => {
-      expect(secondArg.element!.textContent).toBe("2");
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      fireEvent(secondArg.element!, drop());
-      retrieve();
-      expect(secondArg.element!.textContent).toBe("3");
-    });
+  it("should do nothing when dropping onto a non-drop target 5", () => {
+    const initialValue = cmb.getValue();
+    const dragEvent = dragstart();
+    fireEvent(firstArg.element!, dragEvent);
+    const nonDT = cmb.getAst().rootNodes[0].element!;
+    fireEvent(nonDT, drop());
+    expect(cmb.getValue()).toBe(initialValue);
+  });
 
-    it("should set the right css class on dragenter 2", () => {
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      const elt = dropTargetEls[3];
-      expect(elt.classList).toContain("blocks-drop-target");
-      dragenterSeq(elt);
-      expect(elt.classList).toContain("blocks-over-target");
-    });
+  it("should update the text on drop to a later point in the file 6", () => {
+    expect(dropTargetEls[3].classList).toContain("blocks-drop-target");
+    // drag the first arg to the drop target
+    const dragEvent = dragstart();
+    fireEvent(firstArg.element!, dragEvent);
+    fireEvent(dropTargetEls[3], drop());
+    expect(cmb.getValue().replace(/\s+/, " ")).toBe("(+ 2 3 1)");
+  });
 
-    it("should set the right css class on dragenter 2’", () => {
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      const elt = secondArg;
-      dragenterSeq(elt);
-    });
+  it("should update the text on drop to an earlier point in the file 7", () => {
+    const dragEvent = dragstart();
+    fireEvent(secondArg.element!, dragEvent);
+    fireEvent(dropTargetEls[0], drop());
+    expect(cmb.getValue().replace("  ", " ")).toBe("(+ 2 1 3)");
+  });
 
-    it("should set the right css class on dragleave 3", () => {
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      const elt = dropTargetEls[3];
-      dragenter();
-      dragleave();
-      expect(elt.classList).not.toContain("blocks-over-target");
-    });
-
-    it("should do nothing when dragging over a non-drop target 4", () => {
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      const nonDT = cmb.getAst().rootNodes[0].element!;
-      dragenterSeq(nonDT);
-      expect(secondArg.element!.classList).not.toContain("blocks-over-target");
-    });
-
-    it("should do nothing when dropping onto a non-drop target 5", () => {
-      const initialValue = cmb.getValue();
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      const nonDT = cmb.getAst().rootNodes[0].element!;
-      fireEvent(nonDT, drop());
-      expect(cmb.getValue()).toBe(initialValue);
-    });
-
-    it("should update the text on drop to a later point in the file 6", () => {
-      expect(dropTargetEls[3].classList).toContain("blocks-drop-target");
-      // drag the first arg to the drop target
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      fireEvent(dropTargetEls[3], drop());
-      expect(cmb.getValue().replace(/\s+/, " ")).toBe("(+ 2 3 1)");
-    });
-
-    it("should update the text on drop to an earlier point in the file 7", () => {
-      const dragEvent = dragstart();
-      fireEvent(secondArg.element!, dragEvent);
-      fireEvent(dropTargetEls[0], drop());
-      expect(cmb.getValue().replace("  ", " ")).toBe("(+ 2 1 3)");
-    });
-
-    /*
+  /*
     it('should move an item to the top level when dragged outside a node 8', function() {
       debugLog('################ 8');
       let dragEvent = dragstart();
@@ -128,17 +118,17 @@ describe("Drag and drop", () => {
     });
     */
 
-    it("should replace a literal that you drag onto 9", () => {
-      const dragEvent = dragstart();
-      fireEvent(firstArg.element!, dragEvent);
-      fireEvent(secondArg.element!, drop());
-      expect(cmb.getValue().replace(/\s+/, " ")).toBe("(+ 1 3)");
-    });
+  it("should replace a literal that you drag onto 9", () => {
+    const dragEvent = dragstart();
+    fireEvent(firstArg.element!, dragEvent);
+    fireEvent(secondArg.element!, drop());
+    expect(cmb.getValue().replace(/\s+/, " ")).toBe("(+ 1 3)");
+  });
 
-    // these two tests seem to fail because dragend is not called.
-    // see https://github.com/react-dnd/react-dnd/issues/455 for more info
+  // these two tests seem to fail because dragend is not called.
+  // see https://github.com/react-dnd/react-dnd/issues/455 for more info
 
-    /*
+  /*
     it('should support dragging plain text to replace a literal 10', function() {
       debugLog('################ 10');
       let elt1 = firstArg.element;
@@ -153,7 +143,7 @@ describe("Drag and drop", () => {
     });
     */
 
-    /*
+  /*
     it('should support dragging plain text onto some whitespace 11', function() {
       debugLog('################ 11');
       let dragEvent = dragstart();
@@ -169,65 +159,64 @@ describe("Drag and drop", () => {
       debugLog('%%%%%%%%%%%%%%%% 11');
     });
     */
-    // TODO(pcardune) reenable
-    xit("save collapsed state when dragging root to be the last child of the next root", async () => {
-      cmb.setValue("(collapse me)\n(+ 1 2)");
-      let firstRoot!: ASTNode;
-      let lastDropTarget!: Element;
-      const retrieve = () => {
-        firstRoot = cmb.getAst().rootNodes[0];
-        lastDropTarget = document.querySelectorAll(".blocks-drop-target")[4];
-      };
-      retrieve();
+  // TODO(pcardune) reenable
+  xit("save collapsed state when dragging root to be the last child of the next root", async () => {
+    cmb.setValue("(collapse me)\n(+ 1 2)");
+    let firstRoot!: ASTNode;
+    let lastDropTarget!: Element;
+    const retrieve = () => {
+      firstRoot = cmb.getAst().rootNodes[0];
+      lastDropTarget = document.querySelectorAll(".blocks-drop-target")[4];
+    };
+    retrieve();
 
-      mouseDown(firstRoot); // click the root
-      keyDown("ArrowLeft", {}, firstRoot); // collapse it
-      expect(firstRoot.element!.getAttribute("aria-expanded")).toBe("false");
-      expect(firstRoot.nid).toBe(0);
-      const dragEvent = dragstart();
-      fireEvent(firstRoot.element!, dragEvent); // drag to the last droptarget
-      fireEvent(lastDropTarget, drop());
-      retrieve();
-      const newFirstRoot = cmb.getAst().rootNodes[0] as FunctionAppNode;
-      const newLastChild = newFirstRoot.fields.args[2];
-      expect(cmb.getValue()).toBe("\n(+ 1 2 (collapse me))");
-      expect(newFirstRoot.element!.getAttribute("aria-expanded")).toBe("true");
-      expect(newLastChild.element!.getAttribute("aria-expanded")).toBe("false");
-    });
+    mouseDown(firstRoot); // click the root
+    keyDown("ArrowLeft", {}, firstRoot); // collapse it
+    expect(firstRoot.element!.getAttribute("aria-expanded")).toBe("false");
+    expect(firstRoot.nid).toBe(0);
+    const dragEvent = dragstart();
+    fireEvent(firstRoot.element!, dragEvent); // drag to the last droptarget
+    fireEvent(lastDropTarget, drop());
+    retrieve();
+    const newFirstRoot = cmb.getAst().rootNodes[0] as FunctionAppNode;
+    const newLastChild = newFirstRoot.fields.args[2];
+    expect(cmb.getValue()).toBe("\n(+ 1 2 (collapse me))");
+    expect(newFirstRoot.element!.getAttribute("aria-expanded")).toBe("true");
+    expect(newLastChild.element!.getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+describe("corner cases", () => {
+  let source!: ASTNode;
+  let target1!: Element;
+  let target2!: Element;
+
+  const retrieve = () => {
+    source = cmb.getAst().rootNodes[0];
+    target1 = document.querySelectorAll(".blocks-drop-target")[1];
+    target2 = document.querySelectorAll(".blocks-drop-target")[2];
+  };
+
+  beforeEach(async () => {
+    cmb.setValue(";comment\n(a)\n(c)\n(define-struct e ())\ng");
+    retrieve();
   });
 
-  describe("corner cases", () => {
-    let source!: ASTNode;
-    let target1!: Element;
-    let target2!: Element;
+  afterEach(() => {
+    teardown();
+  });
 
-    const retrieve = () => {
-      source = cmb.getAst().rootNodes[0];
-      target1 = document.querySelectorAll(".blocks-drop-target")[1];
-      target2 = document.querySelectorAll(".blocks-drop-target")[2];
-    };
+  // TODO(pcardune) reenable
+  xit("regression test for unstable block IDs", async () => {
+    const dragEvent = dragstart();
+    fireEvent(source.element!, dragEvent); // drag to the last droptarget
+    fireEvent(target1, drop());
+  });
 
-    beforeEach(async () => {
-      cmb.setValue(";comment\n(a)\n(c)\n(define-struct e ())\ng");
-      retrieve();
-    });
-
-    afterEach(() => {
-      teardown();
-    });
-
-    // TODO(pcardune) reenable
-    xit("regression test for unstable block IDs", async () => {
-      const dragEvent = dragstart();
-      fireEvent(source.element!, dragEvent); // drag to the last droptarget
-      fireEvent(target1, drop());
-    });
-
-    // TODO(pcardune) reenable
-    xit("regression test for empty identifierLists returning a null location", async () => {
-      const dragEvent = dragstart();
-      fireEvent(source.element!, dragEvent); // drag to the last droptarget
-      fireEvent(target2, drop());
-    });
+  // TODO(pcardune) reenable
+  xit("regression test for empty identifierLists returning a null location", async () => {
+    const dragEvent = dragstart();
+    fireEvent(source.element!, dragEvent); // drag to the last droptarget
+    fireEvent(target2, drop());
   });
 });

--- a/packages/codemirror-blocks/src/edits/performEdits.ts
+++ b/packages/codemirror-blocks/src/edits/performEdits.ts
@@ -142,22 +142,23 @@ export function isChangeObject(
  * Converts an array of Edit objects into an array of change objects
  */
 function editsToChange(
-  edits: EditInterface[],
+  edits: readonly EditInterface[],
   ast: AST,
   text: ReadonlyRangedText
 ): ChangeObject[] {
   // Sort the edits from last to first, so that they don't interfere with
   // each other's source locations or indices.
-  edits.sort((a, b) => poscmp(b.from, a.from));
+  const sortedEdits = [...edits];
+  sortedEdits.sort((a, b) => poscmp(b.from, a.from));
   // Group edits by shared ancestor, so that edits so grouped can be made with a
   // single textual edit.
   const editToEditGroup = groupEditsByAncestor(
-    edits.filter((edit): edit is AstEdit => edit instanceof AstEdit)
+    sortedEdits.filter((edit): edit is AstEdit => edit instanceof AstEdit)
   );
   // Convert the edits into CodeMirror-style change objects
   // (with `from`, `to`, and `text`, but not `removed` or `origin`).
   const changeObjects: ChangeObject[] = [];
-  for (const edit of edits) {
+  for (const edit of sortedEdits) {
     const group = edit instanceof AstEdit && editToEditGroup.get(edit);
     if (group) {
       // Convert the group into a text edit.
@@ -175,7 +176,7 @@ function editsToChange(
 }
 
 export function applyEdits(
-  edits: EditInterface[],
+  edits: readonly EditInterface[],
   ast: AST,
   editor: CMBEditor
 ): Result<{
@@ -212,7 +213,7 @@ export type PerformEditsResult = Result<{
  */
 export const performEdits =
   (
-    edits: EditInterface[],
+    edits: readonly EditInterface[],
     editor: CMBEditor,
     annt?: string
   ): AppThunk<PerformEditsResult> =>


### PR DESCRIPTION
Fixes #597 

At least I think the bug I found is the same one being talked about in that issue. I wrote a test for the "acceptable" behavior since that seemed to be what was previously implemented. If we want to change it to the ideal behavior, that should probably be addressed in a separate issue with a separate PR.

The bug was introduced because we were mutating the order of edits when converting them to change objects, but then relying on that order for calculating focus, so it was using the focus behavior for deleting the dragged node rather than the focus behavior for editing the node that was dropped onto.